### PR TITLE
Handle requests errors and responses with empty body and content-type

### DIFF
--- a/sql/pg_net--0.1.sql
+++ b/sql/pg_net--0.1.sql
@@ -8,6 +8,7 @@ create table net.http_request_queue(
     params jsonb not null,
     headers jsonb not null,
     timeout_milliseconds int not null,
+    error_msg text,
     -- Available for delete after this date
     delete_after timestamp not null
 );

--- a/sql/pg_net--0.1.sql
+++ b/sql/pg_net--0.1.sql
@@ -8,7 +8,6 @@ create table net.http_request_queue(
     params jsonb not null,
     headers jsonb not null,
     timeout_milliseconds int not null,
-    error_msg text,
     -- Available for delete after this date
     delete_after timestamp not null
 );
@@ -23,9 +22,9 @@ create table net.http_response(
     content_type text,
     headers jsonb,
     body text,
-    timed_out bool
+    timed_out bool,
+    error_msg text
 );
-
 
 -- Blocks until an http_request is complete
 -- API: Private

--- a/test/expected/test_http_get.out
+++ b/test/expected/test_http_get.out
@@ -24,3 +24,8 @@ rollback;
     -- from
         -- request;
 -- rollback;
+-- TODO run these tests:
+-- request with invalid protocol
+-- select net.http_get('net://supabase.io');
+-- request with invalid hostname
+-- select net.http_get('http://new.ycombinator.com');

--- a/test/expected/test_http_get.out
+++ b/test/expected/test_http_get.out
@@ -29,3 +29,5 @@ rollback;
 -- select net.http_get('net://supabase.io');
 -- request with invalid hostname
 -- select net.http_get('http://new.ycombinator.com');
+-- request with NULL body and content_type
+-- select net.http_get('http://wikipedia.org');

--- a/test/sql/test_http_get.sql
+++ b/test/sql/test_http_get.sql
@@ -28,3 +28,5 @@ rollback;
 -- select net.http_get('net://supabase.io');
 -- request with invalid hostname
 -- select net.http_get('http://new.ycombinator.com');
+-- request with NULL body and content_type
+-- select net.http_get('http://wikipedia.org');

--- a/test/sql/test_http_get.sql
+++ b/test/sql/test_http_get.sql
@@ -22,3 +22,9 @@ rollback;
     -- from
         -- request;
 -- rollback;
+
+-- TODO run these tests:
+-- request with invalid protocol
+-- select net.http_get('net://supabase.io');
+-- request with invalid hostname
+-- select net.http_get('http://new.ycombinator.com');


### PR DESCRIPTION
Fixes #4. When doing invalid requests:

```sql
-- invalid protocol
select net.http_get('net://supabase.io');

-- invalid host name
select net.http_get('http://new.ycombinator.com');
```

We now get:

```sql
select id, url, error_msg from net.http_request_queue;

┌────┬────────────────────────────┬────────────────────────────┐
│ id │            url             │         error_msg          │
├────┼────────────────────────────┼────────────────────────────┤
│  1 │ net://supabase.io          │ Unsupported protocol       │
│  2 │ http://new.ycombinator.com │ Couldn't resolve host name │
└────┴────────────────────────────┴────────────────────────────┘
```

Additionally, also handles cases where there's no body and content-type:

```sql
select net.http_get('http://wikipedia.org');

select id, status_code, content_type, body from net.http_response;
┌────┬─────────────┬──────────────┬────────┐
│ id │ status_code │ content_type │  body  │
├────┼─────────────┼──────────────┼────────┤
│  1 │         301 │ [NULL]       │ [NULL] │
└────┴─────────────┴──────────────┴────────┘
```