### PR TITLE
feat: support POST

### DIFF
--- a/sql/pg_net--0.1.sql
+++ b/sql/pg_net--0.1.sql
@@ -15,7 +15,7 @@ create table net.http_request_queue(
     params jsonb not null,
     headers jsonb not null,
     content_type text,
-    body text,
+    body bytea,
     timeout_milliseconds int not null,
     -- Available for delete after this date
     delete_after timestamp not null
@@ -108,7 +108,7 @@ create or replace function net.http_post(
     -- ContentType of the POST request
     content_type text,
     -- body of the POST request
-    body text,
+    body bytea,
     -- key/value pairs to be url encoded and appended to the `url`
     params jsonb DEFAULT '{}'::jsonb,
     -- key/values to be included in request headers

--- a/sql/pg_net--0.1.sql
+++ b/sql/pg_net--0.1.sql
@@ -1,12 +1,21 @@
 create schema if not exists net;
 
+create domain http_method as text
+check (
+    value ilike 'get' or
+    value ilike 'post'
+);
+
 -- Store pending requests. The background worker reads from here
 -- API: Private
 create table net.http_request_queue(
     id bigserial primary key,
+    method http_method not null,
     url text not null,
     params jsonb not null,
     headers jsonb not null,
+    content_type text,
+    body text,
     timeout_milliseconds int not null,
     -- Available for delete after this date
     delete_after timestamp not null
@@ -82,8 +91,8 @@ declare
     request_id bigint;
 begin
     -- Add to the request queue
-    insert into net.http_request_queue(url, params, headers, timeout_milliseconds, delete_after)
-    values (url, params, headers, timeout_milliseconds, timezone('utc', now()) + ttl)
+    insert into net.http_request_queue(method, url, params, headers, content_type, body, timeout_milliseconds, delete_after)
+    values ('GET', url, params, headers, null, null, timeout_milliseconds, timezone('utc', now()) + ttl)
     returning id
     into request_id;
 
@@ -91,6 +100,53 @@ begin
 end
 $$;
 
+-- Interface to make an async request
+-- API: Public
+create or replace function net.http_post(
+    -- url for the request
+    url text,
+    -- ContentType of the POST request
+    content_type text,
+    -- body of the POST request
+    body text,
+    -- key/value pairs to be url encoded and appended to the `url`
+    params jsonb DEFAULT '{}'::jsonb,
+    -- key/values to be included in request headers
+    headers jsonb DEFAULT '{}'::jsonb,
+    -- the maximum number of milliseconds the request may take before being cancelled
+    timeout_milliseconds int DEFAULT 1000,
+    -- the minimum amount of time the response should be persisted
+    ttl interval default '3 days',
+    -- when `true`, return immediately. when `false` wait for the request to complete before returning
+    async bool default true
+)
+    -- request_id reference
+    returns bigint
+    strict
+    volatile
+    parallel safe
+    language plpgsql
+as $$
+declare
+    request_id bigint;
+    respone_rec net.http_response;
+begin
+    -- Add to the request queue
+    insert into net.http_request_queue(method, url, params, headers, content_type, body, timeout_milliseconds, delete_after)
+    values ('POST', url, params, headers, content_type, body, timeout_milliseconds, timezone('utc', now()) + ttl)
+    returning id
+    into request_id;
+
+    -- If request is async, return id immediately
+    if async then
+        return request_id;
+    end if;
+
+    -- If sync, wait for the request to complete before returning
+    perform net._await_response(request_id);
+    return request_id;
+end
+$$;
 
 -- Lifecycle states of a request (all protocols)
 -- API: Public

--- a/src/worker.c
+++ b/src/worker.c
@@ -118,7 +118,6 @@ header_array_to_slist(ArrayType *array, struct curl_slist *headers)
 		if (isnull) continue;
 
 		header = TextDatumGetCString(value);
-		elog(DEBUG1, "Request header \"%s\"\n", header);
 		headers = curl_slist_append(headers, header);
 	}
 	array_free_iterator(iterator);


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the new behavior?

Support POST requests via `net.http_post()`. Right now the function is mostly copypasting from `http_get()`, but I think in the future this should be refactored to use a (public?) generic function `net.http()`.

@olirice the order of arguments to `net.http_post()` is a bit out of place since required arguments have to be listed first - let me know if you want them changed. Also I see I'm failing the pytest stuff - anything I should look at? Do you want me to add a test as well? (haven't looked at how it's setup)

@steve-chavez CMIIW, we currently ignore `params` and `headers` in the request right? Atm `content_type` is handled separately, but I think we should handle it together with `headers`. In retrospect, I probably should've omitted `content_type` in the SQL too... (was following pgsql-http) Also, let me know if I've freed the palloc'd stuff properly.

## Additional context

Closes #6.

## TODOs

- [x] merge `Content-Type` into `headers`
- [x] convert `body` to byte array to align with #5
- [x] `http_post` fails when `body` is null
- [ ] check memory leak
