### PR TITLE
remove async param from http_get

### DIFF
--- a/sql/pg_net--0.1.sql
+++ b/sql/pg_net--0.1.sql
@@ -69,9 +69,7 @@ create or replace function net.http_get(
     -- the maximum number of milliseconds the request may take before being cancelled
     timeout_milliseconds int DEFAULT 1000,
     -- the minimum amount of time the response should be persisted
-    ttl interval default '3 days',
-    -- when `true`, return immediately. when `false` wait for the request to complete before returning
-    async bool default true
+    ttl interval default '3 days'
 )
     -- request_id reference
     returns bigint
@@ -82,7 +80,6 @@ create or replace function net.http_get(
 as $$
 declare
     request_id bigint;
-    respone_rec net.http_response;
 begin
     -- Add to the request queue
     insert into net.http_request_queue(url, params, headers, timeout_milliseconds, delete_after)
@@ -90,13 +87,6 @@ begin
     returning id
     into request_id;
 
-    -- If request is async, return id immediately
-    if async then
-        return request_id;
-    end if;
-
-    -- If sync, wait for the request to complete before returning
-    perform net._await_response(request_id);
     return request_id;
 end
 $$;

--- a/test/expected/test_http_collect_response.out
+++ b/test/expected/test_http_collect_response.out
@@ -1,6 +1,6 @@
 begin;
     with req as (
-        select net.http_get('https://supabase.io', async:=true) as id
+        select net.http_get('https://supabase.io') as id
     )
     select
         net.http_collect_response(id, async:=true)

--- a/test/expected/test_http_get.out
+++ b/test/expected/test_http_get.out
@@ -2,7 +2,7 @@
 begin;
     with request as (
         select
-            net.http_get('http://supabase.io', async:=true) as id
+            net.http_get('http://supabase.io') as id
     )
     select
         net.http_collect_response(id)

--- a/test/sql/test_http_collect_response.sql
+++ b/test/sql/test_http_collect_response.sql
@@ -1,7 +1,7 @@
 begin;
 
     with req as (
-        select net.http_get('https://supabase.io', async:=true) as id
+        select net.http_get('https://supabase.io') as id
     )
     select
         net.http_collect_response(id, async:=true)

--- a/test/sql/test_http_get.sql
+++ b/test/sql/test_http_get.sql
@@ -3,7 +3,7 @@ begin;
 
     with request as (
         select
-            net.http_get('http://supabase.io', async:=true) as id
+            net.http_get('http://supabase.io') as id
     )
     select
         net.http_collect_response(id)


### PR DESCRIPTION
### Summary
Remove async parameter from `http_get` and default to always async

### Explanation
The background worker is not able to see uncommitted requests in the `net.http_request_queue` which means creating a request and retrieving the result needs to happen in separate transactions. That is a reasonable hurdle for the async interface but it prevent a sync interface being implemented in terms of the async interface in the sql layer because the work is never visible to the background worker & `_await_response` will hang forever.

resolves #18 