### PR TITLE
Change response body from text to bytea

### DIFF
--- a/sql/pg_net--0.1.sql
+++ b/sql/pg_net--0.1.sql
@@ -29,7 +29,7 @@ create table net._http_response(
     status_code integer,
     content_type text,
     headers jsonb,
-    content text,
+    body bytea,
     timed_out bool,
     error_msg text
 );

--- a/src/worker.c
+++ b/src/worker.c
@@ -56,7 +56,7 @@ body_cb(void *contents, size_t size, size_t nmemb, void *userp)
 {
 	size_t realsize = size * nmemb;
 	StringInfo si = (StringInfo)userp;
-	appendBinaryStringInfo(si, (const char*)contents, (int)realsize);
+	appendBinaryStringInfoNT(si, (const char*)contents, (int)realsize);
 	return realsize;
 }
 
@@ -353,6 +353,8 @@ worker_main(Datum main_arg)
 											false, 1) != SPI_OK_INSERT)
 							{
 								elog(ERROR, "SPI_exec failed: %s", query_insert_response_bad.data);
+
+
 							}
 						} else {
 							int argCount = 6;
@@ -362,6 +364,7 @@ worker_main(Datum main_arg)
 							CurlData *cdata = NULL;
 							char *contentType = NULL;
 							bool timedOut = false;
+							bytea *body_data = NULL;
 
 							curl_easy_getinfo(eh, CURLINFO_RESPONSE_CODE, &http_status_code);
 							curl_easy_getinfo(eh, CURLINFO_CONTENT_TYPE, &contentType);
@@ -379,12 +382,14 @@ worker_main(Datum main_arg)
 							argValues[1] = Int32GetDatum(http_status_code);
 							nulls[1] = ' ';
 
-							argTypes[2] = CSTRINGOID;
-							argValues[2] = CStringGetDatum(cdata->body->data);
-							if(cdata->body->data[0] == '\0')
-								nulls[2] = 'n';
-							else
-								nulls[2] = ' ';
+							argTypes[2] = BYTEAOID;
+
+							body_data = (bytea *) palloc(cdata->body->len + VARHDRSZ);
+							SET_VARSIZE(body_data, cdata->body->len + VARHDRSZ);
+							memcpy(VARDATA(body_data), cdata->body->data, cdata->body->len);
+
+							argValues[2] = PointerGetDatum(body_data);
+							nulls[2] = ' ';
 
 							argTypes[3] = JSONBOID;
 							argValues[3] = JsonbPGetDatum(JsonbValueToJsonb(pushJsonbValue(&cdata->headers, WJB_END_OBJECT, NULL)));
@@ -409,6 +414,7 @@ worker_main(Datum main_arg)
 
 							pfree(cdata->body->data);
 							pfree(cdata->body);
+							pfree(body_data);
 						}
 
 						curl_multi_remove_handle(cm, eh);


### PR DESCRIPTION
Fixes https://github.com/supabase/pg_net/issues/5.

I've checked the result by downloading an image:

```sql
select net.http_get('https://supabase.io/new/images/logo-dark.png');
\copy (select encode(body, 'hex') from net._http_response where id = 1) to 'supa.hex';
```
```bash
xxd -p -r supa.hex > supa.png
## open supa.png with any image viewer
```
(this way of getting the bytea to a file is mentioned in https://stackoverflow.com/a/6731452/4692662)

With this change, plain text media types have to be encoded. This can be done in pure SQL:

```sql
select net.http_get('https://supabase.io');
select encode(body, 'escape') from net._http_response where id = 1;
-- <!DOCTYPE html><html lang="en"....
```

We'd need to accommodate the SQL interface, perhaps it should handle `text/*` and some `application/*` media types for knowing when to encode.