### PR TITLE
Adds TTL in worker

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -19,9 +19,7 @@ net.http_get(
     -- key/values to be included in request headers
     headers jsonb DEFAULT '{}'::jsonb,
     -- the maximum number of milliseconds the request may take before being cancelled
-    timeout_milliseconds int DEFAULT 1000,
-    -- the minimum amount of time the response should be persisted
-    ttl interval default '3 days',
+    timeout_milliseconds int DEFAULT 1000
 )
     -- request_id reference
     returns bigint
@@ -65,9 +63,7 @@ net.http_post(
     -- key/values to be included in request headers
     headers jsonb default '{"Content-Type": "application/json"}'::jsonb,
     -- the maximum number of milliseconds the request may take before being cancelled
-    timeout_milliseconds int default 1000,
-    -- the minimum amount of time the response should be persisted
-    ttl interval default '3 days'
+    timeout_milliseconds int DEFAULT 1000
 )
     -- request_id reference
     returns bigint
@@ -92,7 +88,7 @@ request_id
 
 ### net.http_collect_response
 
-##### description 
+##### description
 Given a `request_id` reference, retrieve the response.
 
 When `async:=false` is set it is recommended that [statement_timeout](https://www.postgresql.org/docs/13/runtime-config-client.html) is set for the maximum amount of time the caller is willing to wait in case the response is slow to populate.

--- a/sql/pg_net--0.1.sql
+++ b/sql/pg_net--0.1.sql
@@ -14,8 +14,11 @@ create table net.http_request_queue(
     url text not null,
     headers jsonb not null,
     body bytea,
-    timeout_milliseconds int not null
+    timeout_milliseconds int not null,
+    created timestamptz not null default now()
 );
+
+create index created_idx on net.http_request_queue (created);
 
 -- Associates a response with a request
 -- API: Private

--- a/test/fixtures.sql
+++ b/test/fixtures.sql
@@ -1,1 +1,3 @@
 create extension pg_net;
+alter system set pg_net.ttl TO '2 seconds';
+select pg_reload_conf();


### PR DESCRIPTION
TTL is `3 days` by default, but can be configured with:

```sql
alter system set pg_net.ttl TO '5 minutes';
select pg_reload_conf();

show pg_net.ttl;
-- 5 minutes
```