### PR TITLE
fix: allow usage of double quotes within json bodies

### DIFF
--- a/sql/pg_net--0.1.sql
+++ b/sql/pg_net--0.1.sql
@@ -192,7 +192,7 @@ begin
         'POST',
         net._encode_url_with_params_array(url, params_array),
         headers,
-        body::text::bytea,
+        convert_to(body::text, 'UTF8'),
         timeout_milliseconds
     )
     returning id

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -16,6 +16,21 @@ def test_http_post_returns_id(sess):
     assert request_id == 1
 
 
+def test_http_post_special_chars_body(sess):
+    """net.http_post returns a bigint id"""
+
+    (request_id,) = sess.execute(
+        """
+        select net.http_post(
+            url:='https://httpbin.org/post',
+            body:=json_build_object('foo', 'ba"r')::jsonb
+        );
+    """
+    ).fetchone()
+
+    assert request_id == 1
+
+
 def test_http_post_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 


### PR DESCRIPTION
A valid json object that includes a double quote escaped within a string causes an error.

Not sure if this is the best way to fix this!

```
postgres=# select json_build_object('foo', 'b"ar')::text;
 json_build_object
-------------------
 {"foo" : "b\"ar"}
(1 row)

postgres=# select json_build_object('foo', 'b"ar')::text::bytea;
ERROR:  invalid input syntax for type bytea

postgres=# select convert_to(json_build_object('foo', 'b"ar')::text, 'UTF8');
              convert_to
--------------------------------------
 \x7b22666f6f22203a2022625c226172227d
(1 row)
```