### PR TITLE
nix: setup for slow response

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -85,6 +85,17 @@ select net.http_get('http://server') from generate_series(1,1000);
 # run `top` on another shell(another `nixops ssh -d pg_net client`) to check the worker behavior
 ```
 
+#### Testing a slow response
+
+```bash
+nixops ssh -d pg_net client
+
+# takes 32 seconds to respond
+select net.http_get('http://server/slow-reply');
+```
+
+#### Destroying the setup
+
 To destroy the instances:
 
 ```bash

--- a/nix/deploy.nix
+++ b/nix/deploy.nix
@@ -62,7 +62,26 @@ in {
       };
     };
 
-    services.nginx.enable = true;
+    services.nginx = {
+      enable = true;
+      package = pkgs.openresty;
+      config = ''
+        events {}
+
+        http {
+          server {
+            listen 0.0.0.0:80 ;
+            listen [::]:80 ;
+            server_name localhost;
+
+            location = /slow-reply {
+              echo_sleep 32.0;
+              echo 'this text will come in response body with HTTP 200 after 5 seconds';
+            }
+          }
+        }
+      '';
+    };
     networking.firewall.allowedTCPPorts = [ 80 ];
   };
 

--- a/shell.nix
+++ b/shell.nix
@@ -25,6 +25,7 @@ mkShell {
       net-with-pg-13
       valgrind-net-with-pg-12
       pythonDeps
+      nixops
     ];
   shellHook = ''
     export NIX_PATH="nixpkgs=${nixpkgs}:."


### PR DESCRIPTION
Confirms #13 happens on the current version. Also that #50 solves it(though still has other issues).

Can be tested on the NixOps env with:

```bash
nixops ssh -d pg_net client

# takes 32 seconds to respond
select net.http_get('http://server/slow-reply');

```