### PR TITLE
fix: alter api functions to be security definer ones

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -8,6 +8,8 @@ Create an HTTP GET request returning the request's id
 !!! note
     HTTP requests are not started until the transaction is committed
 
+!!! note
+    this is a Postgres SECURITY DEFINER function
 
 ##### signature
 ```sql
@@ -51,6 +53,8 @@ Create an HTTP POST request with a JSON body, returning the request's id
 !!! note
     the body's character set encoding matches the database's `server_encoding` setting
 
+!!! note
+    this is a Postgres SECURITY DEFINER function
 
 ##### signature
 ```sql
@@ -98,6 +102,8 @@ When `async:=false` is set it is recommended that [statement_timeout](https://ww
 !!! warning
     `net.http_collect_response` must be in a separate transaction from the calls to `net.http_<method>`
 
+!!! note
+    this is a Postgres SECURITY DEFINER function
 
 ##### signature
 ```sql

--- a/sql/pg_net--0.3--0.4.sql
+++ b/sql/pg_net--0.3--0.4.sql
@@ -1,0 +1,3 @@
+alter function net.http_get(url text, params jsonb, headers jsonb, timeout_milliseconds integer) security definer;
+alter function net.http_post(url text, body jsonb, params jsonb, headers jsonb, timeout_milliseconds integer) security definer;
+alter function net.http_collect_response(request_id bigint, async boolean) security definer;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

other db roles are unable to use the api

## What is the new behavior?

other db roles are able to invoke the api functions

## Additional context

Related: https://github.com/supabase/supabase/issues/4883
