### PR TITLE
Changed httpbin endpoints to Postman Echo endpoints

### DIFF
--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -6,7 +6,7 @@ def test_http_delete_returns_id(sess):
     (request_id,) = sess.execute(
         """
         select net.http_get(
-            url:='https://httpbin.org/delete'
+            url:='https://postman-echo.com/delete'
         );
     """
     ).fetchone()
@@ -21,7 +21,7 @@ def test_http_delete_collect_sync_success(sess):
     (request_id,) = sess.execute(
         """
         select net.http_delete(
-            url:='https://httpbin.org/delete'
+            url:='https://postman-echo.com/delete'
         ,   params:= '{"param-foo": "bar"}'
         ,   headers:= '{"X-Baz": "foo"}'
         );

--- a/test/test_http_headers.py
+++ b/test/test_http_headers.py
@@ -7,7 +7,7 @@ def test_http_headers_set(sess):
     (request_id,) = sess.execute(
         """
         select net.http_get(
-            url:='https://postman-echo.com/get',
+            url:='https://postman-echo.com/headers',
             headers:='{"pytest-header": "pytest-header", "accept": "application/json"}'
         );
     """

--- a/test/test_http_headers.py
+++ b/test/test_http_headers.py
@@ -7,7 +7,7 @@ def test_http_headers_set(sess):
     (request_id,) = sess.execute(
         """
         select net.http_get(
-            url:='https://httpbin.org/headers',
+            url:='https://postman-echo.com/get',
             headers:='{"pytest-header": "pytest-header", "accept": "application/json"}'
         );
     """

--- a/test/test_http_params.py
+++ b/test/test_http_params.py
@@ -5,13 +5,13 @@ def test_http_get_url_params_set(sess):
     """Check that headers are being set
 
     Test url is (use browser):
-    https://httpbin.org/anything?hello=world
+    https://postman-echo.com/get?hello=world
     """
     # Create a request
     (request_id,) = sess.execute(
         """
         select net.http_get(
-            url:='https://httpbin.org/anything',
+            url:='https://postman-echo.com/get',
             params:='{"hello": "world"}'::jsonb
         );
     """
@@ -39,13 +39,13 @@ def test_http_post_url_params_set(sess):
     """Check that headers are being set
 
     Test url is (use browser):
-    https://httpbin.org/anything?hello=world
+    https://postman-echo.com/get?hello=world
     """
     # Create a request
     (request_id,) = sess.execute(
         """
         select net.http_post(
-            url:='https://httpbin.org/anything',
+            url:='https://postman-echo.com/get',
             params:='{"hello": "world"}'::jsonb
         );
     """

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -7,7 +7,7 @@ def test_http_post_returns_id(sess):
     (request_id,) = sess.execute(
         """
         select net.http_post(
-            url:='https://httpbin.org/post',
+            url:='https://postman-echo.com/post',
             body:='{}'::jsonb
         );
     """
@@ -22,7 +22,7 @@ def test_http_post_special_chars_body(sess):
     (request_id,) = sess.execute(
         """
         select net.http_post(
-            url:='https://httpbin.org/post',
+            url:='https://postman-echo.com/post',
             body:=json_build_object('foo', 'ba"r')::jsonb
         );
     """
@@ -38,7 +38,7 @@ def test_http_post_collect_sync_success(sess):
     (request_id,) = sess.execute(
         """
         select net.http_post(
-            url:='https://httpbin.org/post'
+            url:='https://postman-echo.com/post'
         );
     """
     ).fetchone()
@@ -105,7 +105,7 @@ def test_http_post_collect_non_empty_body(sess):
     (request_id,) = sess.execute(
         """
         select net.http_post(
-            url:='https://httpbin.org/post',
+            url:='https://postman-echo.com/post',
             body:='{"hello": "world"}'::jsonb,
             headers:='{"Content-Type": "application/json", "accept": "application/json"}'::jsonb
         );
@@ -156,7 +156,7 @@ def test_http_post_wrong_header_exception(sess):
         sess.execute(
             """
             select net.http_post(
-                url:='https://httpbin.org/post',
+                url:='https://postman-echo.com/post',
                 headers:='{"Content-Type": "application/text"}'::jsonb
             );
         """
@@ -175,7 +175,7 @@ def test_http_post_no_content_type_coerce(sess):
     request_id, = sess.execute(
         """
         select net.http_post(
-            url:='https://httpbin.org/post',
+            url:='https://postman-echo.com/post',
             headers:='{"other": "val"}'::jsonb
         );
     """

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -9,7 +9,7 @@ def test_http_requests_deleted_after_ttl(sess):
     (request_id,) = sess.execute(
         """
         select net.http_get(
-            'https://httpbin.org/anything'
+            'https://postman-echo.com/get'
         );
     """
     ).fetchone()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Test code update.

## What is the current behavior?

Tests' requests to httpbin timeout, which causes them to fail even if the code they are evaluating is fully functional.

## What is the new behavior?

Tests now utilize the [Postman Echo API](https://www.postman.com/postman/workspace/published-postman-templates/overview), which is less likely to timeout, but functionally the same as httpbin.
