### PR TITLE
Fixed broken condition in the check_worker_is_up function

### DIFF
--- a/sql/pg_net.sql
+++ b/sql/pg_net.sql
@@ -20,7 +20,7 @@ create unlogged table net.http_request_queue(
 
 create or replace function net.check_worker_is_up() returns void as $$
 begin
-  if not exists (select pid from pg_stat_activity where backend_type = 'pg_net worker') then
+  if not exists (select pid from pg_stat_activity where backend_type ~ 'pg_net \d+(\.\d+){0,2} worker') then
     raise exception using
       message = 'the pg_net background worker is not up'
     , detail  = 'the pg_net background worker is down due to an internal error and cannot process requests'


### PR DESCRIPTION
## What kind of change does this PR introduce?

### Bug fix:

A [commit](https://github.com/supabase/pg_net/commit/6b8fcf24a46e28bdf99cfec43d027377f1ff5f01) for `worker.c` altered its "is active" message from `"pg_net worker"` to `"pg_net " VERSION " worker"`.

However, the `net.check_worker_is_up()` function in `pg_net.sql` hasn't been revised to accommodate the new "is active" message. Consequently, it inaccurately concludes that the worker is always inactive. I've adjusted its test condition to align with the updated format.

## What is the current behavior?

Even when the worker is active, net.check_worker_is_up() returns:

> `"ERROR: the pg_net background worker is not up" `

## What is the new behavior?

By updating the comparison in net.check_worker_is_up() to support versioning, the function is able to properly detect when the worker is active.

**Old Comparison:**


`... where backend_type = 'pg_net worker')
`

**New Comparison:**

`... where backend_type ~ 'pg_net \d+(\.\d+){0,2} worker')
`

## Additional context

This pull request was informed by an error discussed in [issue 98](https://github.com/supabase/pg_net/issues/98#issue-1838575376). The issuer utilized the net.check_worker_is_up function for debugging purposes. They observed that the function produced inaccurate outcomes:

> - The query SELECT net.check_worker_is_up() generated an error: "ERROR: the pg_net background worker is not up"
> 
> - Manually querying SELECT * from pg_stat_activity displayed a running worker, but the reported backend_type was "pg_net 0.7.1 worker," whereas the function expected "pg_net worker."