### PR TITLE
refactor: get version from Makefile for .control

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,9 @@ all: sql/$(EXTENSION)--$(EXTVERSION).sql
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
+pg_net.control:
+	sed "s/@PG_NET_VERSION@/$(EXTVERSION)/g" pg_net.control.in > pg_net.control
+
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
 
 PG_CONFIG = pg_config

--- a/pg_net.control.in
+++ b/pg_net.control.in
@@ -1,3 +1,3 @@
 comment = 'Async HTTP'
-default_version = '0.7.1'
+default_version = '@PG_NET_VERSION@'
 relocatable = false


### PR DESCRIPTION
This way we define the version on a single place (Makefile EXTVERSION).

Related https://github.com/supabase/pg_net/pull/103