### PR TITLE
chore: compatibility with new python3 packages

### DIFF
--- a/nix/nginxScript.nix
+++ b/nix/nginxScript.nix
@@ -2,6 +2,8 @@
 
 let
   script = ''
+    set -euo pipefail
+
     export PATH=${openresty}/bin:"$PATH"
 
     trap 'jobs -p | xargs kill -9' sigint sigterm exit

--- a/nix/pathodScript.nix
+++ b/nix/pathodScript.nix
@@ -2,6 +2,8 @@
 
 let
   script = ''
+    set -euo pipefail
+
     export PATH=${mitmproxy}/bin:"$PATH"
 
     trap 'jobs -p | xargs kill -9' sigint sigterm exit

--- a/nix/pgScript.nix
+++ b/nix/pgScript.nix
@@ -5,6 +5,8 @@ let
   logMin = if builtins.stringLength LOGMIN == 0 then "WARNING" else LOGMIN; # warning is the default in pg
   ver = builtins.head (builtins.splitVersion postgresql.version);
   script = ''
+    set -euo pipefail
+
     export PATH=${postgresql}/bin:"$PATH"
 
     tmpdir="$(mktemp -d)"

--- a/nix/pgValgrindScript.nix
+++ b/nix/pgValgrindScript.nix
@@ -5,6 +5,8 @@ let
   ver = builtins.head (builtins.splitVersion postgresql.version);
   valgrindLogFile = "valgrindlog";
   script = ''
+    set -euo pipefail
+
     export PATH=${postgresql}/bin:"$PATH"
 
     tmpdir="$(mktemp -d)"

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
-
+from sqlalchemy import text
 
 @pytest.fixture(scope="function")
 def engine():
@@ -16,21 +16,21 @@ def sess(engine):
     session = Session(engine)
 
     # Reset sequences and tables between tests
-    session.execute(
+    session.execute(text(
         """
     create extension if not exists pg_net;
     """
-    )
+    ))
     session.commit()
 
     yield session
 
     session.rollback()
 
-    session.execute(
+    session.execute(text(
         """
     drop extension pg_net cascade;
     create extension if not exists pg_net;
     """
-    )
+    ))
     session.commit()

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -1,3 +1,5 @@
+from sqlalchemy import text
+
 def test_connect(sess):
-    (x,) = sess.execute("select 1").fetchone()
+    (x,) = sess.execute(text("select 1")).fetchone()
     assert x == 1

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -3,13 +3,13 @@ from sqlalchemy import text
 def test_http_delete_returns_id(sess):
     """net.http_delete returns a bigint id"""
 
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_get(
             url:='http://localhost:8080/delete'
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     assert request_id == 1
 
@@ -18,7 +18,7 @@ def test_http_delete_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
     # Create a request
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_delete(
             url:='http://localhost:8080/delete'
@@ -26,7 +26,7 @@ def test_http_delete_collect_sync_success(sess):
         ,   headers:= '{"X-Baz": "foo"}'
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     # Commit so background worker can start
     sess.commit()
@@ -39,7 +39,7 @@ def test_http_delete_collect_sync_success(sess):
     """
         ),
         {"request_id": request_id},
-    ).fetchone()
+        ).fetchone()
 
     assert response is not None
     assert response[0] == "SUCCESS"

--- a/test/test_http_errors.py
+++ b/test/test_http_errors.py
@@ -7,39 +7,39 @@ def test_get_bad_url(sess):
     """net.http_get returns a descriptive errors for bad urls"""
 
     with pytest.raises(Exception) as execinfo:
-        res = sess.execute(
+        res = sess.execute(text(
             """
             select net.http_get('localhost:8888');
         """
-        )
+        ))
     assert "URL using bad/illegal format or missing URL" in str(execinfo)
 
 def test_bad_post(sess):
     """net.http_post with an empty url + body returns an error"""
 
     with pytest.raises(Exception) as execinfo:
-        res = sess.execute(
+        res = sess.execute(text(
             """
             select net.http_post(null, '{"hello": "world"}');
         """
-        )
+        ))
     assert "violates not-null constraint" in str(execinfo)
 
 def test_it_keeps_working_after_many_connection_refused(sess):
     """the worker doesn't crash on many failed responses with connection refused"""
 
-    res = sess.execute(
+    res = sess.execute(text(
         """
         select net.http_get('http://localhost:8888') from generate_series(1,10);
     """
-    )
+    ))
     sess.commit()
 
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_get('http://localhost:9999/p/200');
     """
-    ).fetchone()
+    )).fetchone()
 
     sess.commit()
 
@@ -59,39 +59,39 @@ def test_it_keeps_working_after_many_connection_refused(sess):
 def test_it_keeps_working_after_server_returns_nothing(sess):
     """the worker doesn't crash on many failed responses with server returned nothing"""
 
-    sess.execute(
+    sess.execute(text(
         """
         select net.http_get('http://localhost:9999/p/200:d1') from generate_series(1,10);
     """
-    )
+    ))
     sess.commit()
 
     time.sleep(1.5)
 
-    (error_msg,count) = sess.execute(
+    (error_msg,count) = sess.execute(text(
     """
         select error_msg, count(*) from net._http_response where status_code is null group by error_msg;
     """
-    ).fetchone()
+    )).fetchone()
 
     assert error_msg == "Server returned nothing (no headers, no data)"
     assert count == 10
 
-    sess.execute(
+    sess.execute(text(
         """
         select net.http_get('http://localhost:9999/p/200:b"still_working"') from generate_series(1,10);
     """
-    ).fetchone()
+    )).fetchone()
 
     sess.commit()
 
     time.sleep(1.5)
 
-    (status_code,count) = sess.execute(
+    (status_code,count) = sess.execute(text(
     """
         select status_code, count(*) from net._http_response where status_code = 200 group by status_code;
     """
-    ).fetchone()
+    )).fetchone()
 
     assert status_code == 200
     assert count == 10

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -5,11 +5,11 @@ import time
 def test_http_get_returns_id(sess):
     """net.http_get returns a bigint id"""
 
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_get('https://news.ycombinator.com');
     """
-    ).fetchone()
+    )).fetchone()
 
     assert request_id == 1
 
@@ -18,18 +18,17 @@ def test_http_get_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
     # Create a request
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_get('https://news.ycombinator.com');
     """
-    ).fetchone()
+    )).fetchone()
 
     # Commit so background worker can start
     sess.commit()
 
     # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
+    response = sess.execute(text(
             """
         select * from net._http_collect_response(:request_id, async:=false);
     """
@@ -78,11 +77,11 @@ def test_http_collect_response_async_does_not_exist(sess):
     """Collect a non-existent response with async true"""
 
     # Collect the response, waiting as needed
-    response = sess.execute(
+    response = sess.execute(text(
         """
         select * from net._http_collect_response(1, async:=true);
     """
-    ).fetchone()
+    )).fetchone()
 
     assert response[0] == "ERROR"
     assert "not found" in response[1]
@@ -91,37 +90,37 @@ def test_http_collect_response_async_does_not_exist(sess):
 def test_http_get_responses_have_different_created_times(sess):
     """Ensure the rows in net._http_response have different created times"""
 
-    sess.execute(
+    sess.execute(text(
         """
         select net.http_get('http://localhost:8080/echo-method')
     """
-    )
+    ))
     sess.commit()
 
     time.sleep(1)
 
-    sess.execute(
+    sess.execute(text(
         """
         select net.http_get('http://localhost:8080/echo-method')
     """
-    )
+    ))
     sess.commit()
 
     time.sleep(1)
 
-    sess.execute(
+    sess.execute(text(
         """
         select net.http_get('http://localhost:8080/echo-method')
     """
-    )
+    ))
     sess.commit()
 
     time.sleep(1)
 
-    count = sess.execute(
+    count = sess.execute(text(
             """
         select count(distinct created) from net._http_response;
     """
-    ).scalar()
+    )).scalar()
 
     assert count == 3

--- a/test/test_http_headers.py
+++ b/test/test_http_headers.py
@@ -4,14 +4,14 @@ from sqlalchemy import text
 def test_http_headers_set(sess):
     """Check that headers are being set"""
     # Create a request
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_get(
             url:='http://localhost:8080/headers',
             headers:='{"pytest-header": "pytest-header", "accept": "application/json"}'
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     # Commit so background worker can start
     sess.commit()

--- a/test/test_http_params.py
+++ b/test/test_http_params.py
@@ -5,14 +5,14 @@ def test_http_get_url_params_set(sess):
     """Check that params are being set on GET
     """
     # Create a request
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_get(
             url:='http://localhost:8080/anything',
             params:='{"hello": "world"}'::jsonb
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     # Commit so background worker can start
     sess.commit()
@@ -36,14 +36,14 @@ def test_http_post_url_params_set(sess):
     """Check that params are being set on POST
     """
     # Create a request
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_post(
             url:='http://localhost:8080/anything',
             params:='{"hello": "world"}'::jsonb
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     # Commit so background worker can start
     sess.commit()

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -4,14 +4,14 @@ from sqlalchemy import text
 def test_http_post_returns_id(sess):
     """net.http_post returns a bigint id"""
 
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
             body:='{}'::jsonb
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     assert request_id == 1
 
@@ -19,14 +19,14 @@ def test_http_post_returns_id(sess):
 def test_http_post_special_chars_body(sess):
     """net.http_post returns a bigint id"""
 
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
             body:=json_build_object('foo', 'ba"r')::jsonb
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     assert request_id == 1
 
@@ -35,13 +35,13 @@ def test_http_post_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
     # Create a request
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_post(
             url:='http://localhost:8080/post'
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     # Commit so background worker can start
     sess.commit()
@@ -98,7 +98,7 @@ def test_http_post_collect_non_empty_body(sess):
     """Collect a response async before completed"""
 
     # Create a request
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
@@ -106,7 +106,7 @@ def test_http_post_collect_non_empty_body(sess):
             headers:='{"Content-Type": "application/json", "accept": "application/json"}'::jsonb
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     # Commit so background worker can start
     sess.commit()
@@ -148,14 +148,14 @@ def test_http_post_wrong_header_exception(sess):
     did_raise = False
 
     try:
-        sess.execute(
+        sess.execute(text(
             """
             select net.http_post(
                 url:='http://localhost:8080/post',
                 headers:='{"Content-Type": "application/text"}'::jsonb
             );
         """
-        ).fetchone()
+        )).fetchone()
     except:
         sess.rollback()
         did_raise = True
@@ -167,17 +167,17 @@ def test_http_post_no_content_type_coerce(sess):
     """Confirm that a missing content type coerces to application/json"""
 
     # Create a request
-    request_id, = sess.execute(
+    request_id, = sess.execute(text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
             headers:='{"other": "val"}'::jsonb
         );
     """
-    ).fetchone()
+    )).fetchone()
 
 
-    headers, = sess.execute(
+    headers, = sess.execute(text(
         """
         select
             headers
@@ -185,7 +185,7 @@ def test_http_post_no_content_type_coerce(sess):
             net.http_request_queue
         where
             id = :request_id
-    """, {"request_id": request_id}
+    """), {"request_id": request_id}
     ).fetchone()
 
     assert headers["Content-Type"] == "application/json"
@@ -195,14 +195,14 @@ def test_http_post_no_content_type_coerce(sess):
 def test_http_post_empty_body(sess):
     """net.http_post can post a null body"""
 
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_post(
             url:='http://localhost:8080/echo-method',
             body:=null
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     sess.commit()
 

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -6,13 +6,13 @@ from sqlalchemy import text
 def test_http_requests_deleted_after_ttl(sess):
     """Check that http requests are deleted within a few seconds of their ttl"""
     # Create a request
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_get(
             'http://localhost:8080/anything'
         );
     """
-    ).fetchone()
+    )).fetchone()
 
     # Commit so background worker can start
     sess.commit()

--- a/test/test_http_timeout.py
+++ b/test/test_http_timeout.py
@@ -6,11 +6,11 @@ from sqlalchemy import text
 def test_http_get_timeout_reached(sess):
     """net.http_get with timeout errs on a slow reply"""
 
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_get(url := 'http://localhost:9999/p/200:b"wait%20for%20three%20seconds"pr,3');
     """
-    ).fetchone()
+    )).fetchone()
 
     sess.commit()
 
@@ -30,11 +30,11 @@ def test_http_get_timeout_reached(sess):
 def test_http_get_succeed_with_gt_timeout(sess):
     """net.http_get with timeout succeeds when the timeout is greater than the slow reply response time"""
 
-    (request_id,) = sess.execute(
+    (request_id,) = sess.execute(text(
         """
         select net.http_get(url := 'http://localhost:9999/p/200:b"wait%20for%20three%20seconds"pr,3', timeout_milliseconds := 3500);
     """
-    ).fetchone()
+    )).fetchone()
 
     sess.commit()
 
@@ -54,7 +54,7 @@ def test_http_get_succeed_with_gt_timeout(sess):
 def test_many_slow_mixed_with_fast(sess):
     """many fast responses finish despite being mixed with slow responses, the fast responses will wait the timeout duration"""
 
-    sess.execute(
+    sess.execute(text(
         """
         select
           net.http_get(url := 'http://localhost:9999/p/200')
@@ -63,17 +63,17 @@ def test_many_slow_mixed_with_fast(sess):
         , net.http_get(url := 'http://localhost:9999/p/200:pr,f')
         from generate_series(1,25) _;
     """
-    )
+    ))
 
     sess.commit()
 
     time.sleep(3)
 
-    (status_code,count) = sess.execute(
+    (status_code,count) = sess.execute(text(
     """
         select status_code, count(*) from net._http_response where status_code = 200 group by status_code;
     """
-    ).fetchone()
+    )).fetchone()
 
     assert status_code == 200
     assert count == 50

--- a/test/test_worker_error.py
+++ b/test/test_worker_error.py
@@ -1,3 +1,4 @@
+from sqlalchemy import text
 import pytest
 import time
 
@@ -5,16 +6,16 @@ def test_http_get_error_when_worker_down(sess):
     """net.http_get returns an error when pg background worker is down"""
 
     # kill the bg worker manually
-    sess.execute("""
+    sess.execute(text("""
         select pg_terminate_backend((select pid from pg_stat_activity where backend_type = 'pg_net worker'));
-    """)
+    """))
 
     time.sleep(1);
 
     with pytest.raises(Exception) as execinfo:
-        res = sess.execute(
+        res = sess.execute(text(
             """
             select net.check_worker_is_up();
         """
-        )
+        ))
     assert "the pg_net background worker is not up" in str(execinfo)


### PR DESCRIPTION
All sqlalchemy `sess.execute` must be used with `text()` otherwise it will fail with:

```
sqlalchemy.exc.ArgumentError: Textual SQL expression
```

Also make all bash scripts fail fast.

Clears item 1 of https://github.com/supabase/pg_net/issues/106.