### PR TITLE
feat: allow reconfiguring pg_net w/o a db restart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PG_CFLAGS = -Wno-declaration-after-statement
+PG_CFLAGS = -Werror -Wno-declaration-after-statement
 EXTENSION = pg_net
 EXTVERSION = 0.7.3
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+PG_CFLAGS = -Wno-declaration-after-statement
 EXTENSION = pg_net
 EXTVERSION = 0.7.3
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ create extension pg_net;
 
 ---
 
-# Extension Configuration:
+# Extension Configuration
 
 the extension creates 3 configurable variables:
 
@@ -145,24 +145,34 @@ the extension creates 3 configurable variables:
 2. **pg_net.ttl** _(default: 6 hours)_: An interval that defines the max time a row in the _`net.http_response`_ will live before being deleted
 3. **pg_net.database_name** _(default: 'postgres')_: A string that defines which database the extension is applied to
 
-All these variables can be viewed with the following command:
+All these variables can be viewed with the following commands:
 ```sql
-select  * from pg_settings WHERE name LIKE 'pg_net%'
+show pg_net.batch_size;
+show pg_net.ttl;
+show pg_net.database_name;
 ```
 
-The postgres.conf file can be found with the following SQL command:
-```sql
-SHOW config_file;
+You can change these by editing the `postgresql.conf` file (find it with `SHOW config_file;`) or with `ALTER SYSTEM`:
+
+```
+alter system set pg_net.ttl to '1 hour'
+alter system set pg_net.batch_size to 500;
 ```
 
-You can change the variables by adding any of the following line to your postgres.conf file
+Then, reload the settings and restart the `pg_net` background worker with:
+
 ```
-pg_net.batch_size = <new integer>
-pg_net.ttl = '<new ttl interval>'
-pg_net.database_name = '<database name>'
+select net.worker_restart();
 ```
 
-After saving the file, you can execute `SELECT pg_reload_conf()` to update _postgres.conf_ for your database. If the extension does not respond to the update, it may be necessary to restart your database.
+Note that doing `ALTER SYSTEM` requires SUPERUSER but on PostgreSQL >= 15, you can do:
+
+```
+grant alter system on parameter pg_net.ttl to <role>;
+grant alter system on parameter pg_net.batch_size to <role>;
+```
+
+To allow regular users to update `pg_net` settings.
 
 # Requests API
 

--- a/nix/nginxScript.nix
+++ b/nix/nginxScript.nix
@@ -6,7 +6,7 @@ let
 
     export PATH=${openresty}/bin:"$PATH"
 
-    trap 'jobs -p | xargs kill -9' sigint sigterm exit
+    trap 'killall openresty' sigint sigterm exit
 
     openresty -p nix/nginx &
 

--- a/nix/pgScript.nix
+++ b/nix/pgScript.nix
@@ -22,7 +22,7 @@ let
 
     options="-F -c listen_addresses=\"\" -c log_min_messages=${logMin} -k $PGDATA"
 
-    ext_options="-c shared_preload_libraries=\"pg_net\" -c pg_net.ttl=\"4 seconds\""
+    ext_options="-c shared_preload_libraries=\"pg_net\""
 
     pg_ctl start -o "$options" -o "$ext_options"
 

--- a/sql/pg_net.sql
+++ b/sql/pg_net.sql
@@ -353,5 +353,14 @@ begin
 end;
 $$;
 
+create or replace function net.worker_restart() returns bool as $$
+  select pg_reload_conf();
+  select pg_terminate_backend(pid)
+  from pg_stat_activity
+  where backend_type ilike '%pg_net%';
+$$
+security definer
+language sql;
+
 grant all on schema net to postgres;
 grant all on all tables in schema net to postgres;

--- a/test/test_worker_error.py
+++ b/test/test_worker_error.py
@@ -16,12 +16,11 @@ def test_success_when_worker_is_up(sess):
 def test_http_get_error_when_worker_down(sess):
     """net.http_get returns an error when pg background worker is down"""
 
-    # kill the bg worker manually
     sess.execute(text("""
-        select pg_terminate_backend((select pid from pg_stat_activity where backend_type ilike '%pg_net%'));
+        select net.worker_restart();
     """))
 
-    time.sleep(1);
+    time.sleep(0.1)
 
     with pytest.raises(Exception) as execinfo:
         res = sess.execute(text(


### PR DESCRIPTION
Otherwise changing a pg_net config requires a restart of the whole database cluster.

Now users can do:

```sql
alter system set pg_net.ttl to '1 hour';
alter system set pg_net.batch_size to 500;

select net.worker_restart();
```