### PR TITLE
Update README.md | Added warning about updating config variables on S…

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,8 @@ show pg_net.ttl;
 show pg_net.database_name;
 ```
 
+> NOTE: PG_NET variables cannot be modified on Supabase managed instances
+
 You can change these by editing the `postgresql.conf` file (find it with `SHOW config_file;`) or with `ALTER SYSTEM`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ show pg_net.ttl;
 show pg_net.database_name;
 ```
 
-> NOTE: PG_NET variables cannot be modified on Supabase managed instances
+> NOTE: PG_NET config variables cannot be modified on Supabase managed instances
 
 You can change these by editing the `postgresql.conf` file (find it with `SHOW config_file;`) or with `ALTER SYSTEM`:
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs Update

## What is the current behavior?

There are no warnings that config variables cannot be updated on Supabase. The only variables that can be modified are outlined in the platform documentation:
- https://supabase.com/docs/guides/platform/custom-postgres-config

## What is the new behavior?

Added minimal warning that config variables, such as ttl or batch_size, cannot be changed on Supabase managed instances