### PR TITLE
feat: show libcurl version

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -421,7 +421,7 @@ _PG_init(void)
 	worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
 	snprintf(worker.bgw_library_name, BGW_MAXLEN, "pg_net");
 	snprintf(worker.bgw_function_name, BGW_MAXLEN, "worker_main");
-	snprintf(worker.bgw_name, BGW_MAXLEN, "pg_net " EXTVERSION " worker");
+	snprintf(worker.bgw_name, BGW_MAXLEN, "pg_net " EXTVERSION " worker using %s", curl_version());
 	worker.bgw_restart_time = 1;
 	worker.bgw_main_arg = (Datum) 0;
 	worker.bgw_notify_pid = 0;

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -7,7 +7,7 @@ def test_http_get_returns_id(sess):
 
     (request_id,) = sess.execute(text(
         """
-        select net.http_get('https://news.ycombinator.com');
+        select net.http_get('http://localhost:8080');
     """
     )).fetchone()
 
@@ -20,7 +20,7 @@ def test_http_get_collect_sync_success(sess):
     # Create a request
     (request_id,) = sess.execute(text(
         """
-        select net.http_get('https://news.ycombinator.com');
+        select net.http_get('http://localhost:8080');
     """
     )).fetchone()
 

--- a/test/test_worker_version.py
+++ b/test/test_worker_version.py
@@ -1,0 +1,16 @@
+from sqlalchemy import text
+import pytest
+import time
+
+def test_showing_worker_libcurl_version(sess):
+    """the backend type shows the worker version and the libcurl version"""
+
+    # wait for worker to start in case another test restarted it
+    time.sleep(1)
+
+    (result,) = sess.execute(
+        """
+        select backend_type like 'pg_net % worker using libcurl%' from pg_stat_activity where backend_type like '%pg_net%';
+        """
+    ).fetchone()
+    assert result is True


### PR DESCRIPTION
Closes https://github.com/supabase/pg_net/issues/121

Now the version shows like:

```sql
select backend_type from pg_stat_activity where backend_type like '%pg_net%';
                                         backend_type                                          
-----------------------------------------------------------------------------------------------
 pg_net 0.7.3 worker using libcurl/7.73.0 OpenSSL/1.1.1h zlib/1.3 libssh2/1.9.0 nghttp2/1.41.0
(1 row)
```