### PR TITLE
test: resolves ipv6 only host

### DIFF
--- a/nix/nginx/conf/nginx.conf
+++ b/nix/nginx/conf/nginx.conf
@@ -16,4 +16,12 @@ http {
 
     include custom.conf;
   }
+
+  server {
+    listen [::]:8888 ipv6only=on;
+
+    location / {
+      echo 'Hello ipv6 only';
+    }
+  }
 }

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -149,3 +149,28 @@ def test_http_get_collect_with_redirect(sess):
 
     assert response is not None
     assert "I got redirected" in response[2]
+
+def test_http_get_ipv6(sess):
+    """Can resolve an ipv6 only server"""
+
+    # Create a request
+    (request_id,) = sess.execute(text(
+        """
+        select net.http_get('http://localhost:8888/');
+    """
+    )).fetchone()
+
+    # Commit so background worker can start
+    sess.commit()
+
+    # Collect the response, waiting as needed
+    response = sess.execute(text(
+            """
+        select * from net._http_collect_response(:request_id, async:=false);
+    """
+        ),
+        {"request_id": request_id},
+    ).fetchone()
+
+    assert response is not None
+    assert "Hello ipv6 only" in response[2]


### PR DESCRIPTION
Includes an ipv6 only nginx host:

```nginx
  server {
    listen [::]:8888 ipv6only=on;

    location / {
      echo 'Hello ipv6 only';
    }
  }
```

And tests it with pg_net.