### PR TITLE
feat: use CURLOPT_PROTOCOLS_STR with libcurl >= 7.85.0

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -150,7 +150,11 @@ static CURLMcode init(CURLM *cm, char *method, char *url, int timeout_millisecon
 	curl_easy_setopt(eh, CURLOPT_FOLLOWLOCATION, true);
 	if (log_min_messages <= DEBUG1)
 		curl_easy_setopt(eh, CURLOPT_VERBOSE, 1L);
+#if LIBCURL_VERSION_NUM >= 0x075500 /* libcurl 7.85.0 */
+	curl_easy_setopt(eh, CURLOPT_PROTOCOLS_STR, "http,https");
+#else
 	curl_easy_setopt(eh, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
 	return curl_multi_add_handle(cm, eh);
 }
 


### PR DESCRIPTION

## What kind of change does this PR introduce?

Replace deprecated libcurl symbols

## What is the current behavior?

pg_net is using `CURLOPT_PROTOCOLS` which was deprecated in libcurl 7.85.0, causing build error:

    src/worker.c: In function 'init':
    src/worker.c:153:9: error: 'CURLOPT_PROTOCOLS' is deprecated: since 7.85.0. Use CURLOPT_PROTOCOLS_STR [8;;https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wdeprecated-declarations-Werror=deprecated-declarations8;;]
      153 |         curl_easy_setopt(eh, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
          |         ^~~~~~~~~~~~~~~~
    In file included from src/worker.c:30:
    /nix/store/3k4czsnh3wg9liji56v4kjdz3p1mxhsj-curl-8.6.0-dev/include/curl/curl.h:1745:3: note: declared here
     1745 |   CURLOPTDEPRECATED(CURLOPT_PROTOCOLS, CURLOPTTYPE_LONG, 181,
          |   ^~~~~~~~~~~~~~~~~
    cc1: all warnings being treated as errors

## What is the new behavior?

pg_net builds correctly with libcurl >=7.85.0

## Additional context

Add any other context or screenshots.
