### PR TITLE
fix: CURLINFO_RESPONSE_CODE datatype

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -350,7 +350,7 @@ worker_main(Datum main_arg)
 						} else {
 							CurlData *cdata = NULL;
 							char *contentType = NULL;
-							int http_status_code;
+							long http_status_code;
 
 							curl_easy_getinfo(eh, CURLINFO_RESPONSE_CODE, &http_status_code);
 							curl_easy_getinfo(eh, CURLINFO_CONTENT_TYPE, &contentType);


### PR DESCRIPTION
We should be using `long` instead of `int`:
https://curl.se/libcurl/c/CURLINFO_RESPONSE_CODE.html

Error message when compiling:

```
src/worker.c: In function ‘worker_main’:
src/worker.c:355:57: error: call to ‘_curl_easy_getinfo_err_long’ declared with attribute warning: curl_easy_getinfo expects a pointer to long for this info [-Werror=attribute-warning]
  355 |                                                         curl_easy_getinfo(eh, CURLINFO_RESPONSE_CODE, &http_status_code);
      |                                                         ^
```
