### PR TITLE
Fix malformed headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # PG_NET
-*A PostgreSQL extension that enables asynchronous (non-blocking) HTTP/HTTPS requests with SQL*
+*A PostgreSQL extension that enables asynchronous (non-blocking) HTTP/HTTPS requests with SQL*.
+
+Requires libcurl >= 7.83.
 
 ![PostgreSQL version](https://img.shields.io/badge/postgresql-12+-blue.svg)
 [![License](https://img.shields.io/pypi/l/markdown-subtemplate.svg)](https://github.com/supabase/pg_net/blob/master/LICENSE)

--- a/nix/nginx/conf/custom.conf
+++ b/nix/nginx/conf/custom.conf
@@ -45,3 +45,7 @@ location /redirect_me {
 location /to_here {
   echo 'I got redirected';
 }
+
+location /pathological {
+  pathological;
+}

--- a/nix/nginxScript.nix
+++ b/nix/nginxScript.nix
@@ -1,9 +1,23 @@
-{ nginx, nginxModules, writeShellScriptBin } :
+{ lib, fetchFromGitHub, nginx, nginxModules, writeShellScriptBin } :
 
 let
+  ngx_pathological = rec {
+    name = "ngx_pathological";
+    version = "0.1";
+    src = fetchFromGitHub {
+      owner  = "steve-chavez";
+      repo   = name;
+      rev    = "46a6d48910b482cf82ecd8a3fce448498cc9f886";
+      sha256 = "sha256-unPSFxbuvv5chyPKDRaKvxuekz3tPmhHiVzZzX1D4lk=";
+    };
+    meta = with lib; {
+      license = with licenses; [ mit ];
+    };
+  };
   customNginx = nginx.override {
     modules = [
       nginxModules.echo
+      ngx_pathological
     ];
   };
   script = ''

--- a/nix/ngx_pathological.nix
+++ b/nix/ngx_pathological.nix
@@ -1,0 +1,17 @@
+{ stdenv, postgresql, curl }:
+
+stdenv.mkDerivation {
+  name = "pg_net";
+
+  buildInputs = [ postgresql curl ];
+
+  src = ../.;
+
+  installPhase = ''
+    mkdir -p $out/bin
+    install -D pg_net.so -t $out/lib
+
+    install -D -t $out/share/postgresql/extension sql/*.sql
+    install -D -t $out/share/postgresql/extension pg_net.control
+  '';
+}

--- a/src/util.h
+++ b/src/util.h
@@ -1,8 +1,6 @@
 #ifndef UTIL_H
 #define UTIL_H
 
-#include <utils/jsonb.h>
-
 #define CURL_EZ_SETOPT(hdl, opt, prm) \
   do { \
       if (curl_easy_setopt(hdl, opt, prm) != CURLE_OK) \
@@ -24,6 +22,5 @@
 
 extern struct curl_slist *pg_text_array_to_slist(ArrayType *array,
                                                  struct curl_slist *headers);
-extern void parseHeaders(char *contents, JsonbParseState *headers);
 
 #endif

--- a/src/worker.c
+++ b/src/worker.c
@@ -418,8 +418,6 @@ void pg_net_worker(Datum main_arg) {
 void
 _PG_init(void)
 {
-  BackgroundWorker worker;
-
   if (IsBinaryUpgrade) {
       return;
   }
@@ -430,16 +428,14 @@ _PG_init(void)
                       "configuration variable in postgresql.conf."));
   }
 
-  MemSet(&worker, 0, sizeof(BackgroundWorker));
-  worker.bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION;
-  worker.bgw_start_time = BgWorkerStart_RecoveryFinished;
-  snprintf(worker.bgw_library_name, BGW_MAXLEN, "pg_net");
-  snprintf(worker.bgw_function_name, BGW_MAXLEN, "pg_net_worker");
-  snprintf(worker.bgw_name, BGW_MAXLEN, "pg_net " EXTVERSION " worker");
-  worker.bgw_restart_time = 1;
-  worker.bgw_main_arg = (Datum) 0;
-  worker.bgw_notify_pid = 0;
-  RegisterBackgroundWorker(&worker);
+  RegisterBackgroundWorker(&(BackgroundWorker){
+    .bgw_flags = BGWORKER_SHMEM_ACCESS | BGWORKER_BACKEND_DATABASE_CONNECTION,
+    .bgw_start_time = BgWorkerStart_RecoveryFinished,
+    .bgw_library_name = "pg_net",
+    .bgw_function_name = "pg_net_worker",
+    .bgw_name = "pg_net " EXTVERSION " worker",
+    .bgw_restart_time = 1,
+  });
 
   DefineCustomStringVariable("pg_net.ttl",
                  "time to live for request/response rows",

--- a/test/test_http_malformed_headers.py
+++ b/test/test_http_malformed_headers.py
@@ -1,0 +1,112 @@
+from sqlalchemy import text
+
+def test_http_header_missing_value(sess):
+    """Check that a `MissingValue: ` header is processed correctly"""
+
+    (request_id,) = sess.execute(text(
+        """
+        select net.http_get(
+            url:='http://localhost:8080/pathological?malformed-header=missing-value'
+        );
+    """
+    )).fetchone()
+
+    # Commit so background worker can start
+    sess.commit()
+
+    # Collect the response, waiting as needed
+    response = sess.execute(
+        text(
+            """
+        select * from net._http_collect_response(:request_id, async:=false);
+    """
+        ),
+        {"request_id": request_id},
+    ).fetchone()
+    assert response is not None
+    assert response[0] == "SUCCESS"
+    assert "MissingValue" in response[2]
+
+
+def test_http_header_injection(sess):
+    """Check that a `HeaderInjection Injected-Header: This header contains an injection` header fails without crashing"""
+
+    (request_id,) = sess.execute(text(
+        """
+        select net.http_get(
+            url:='http://localhost:8080/pathological?malformed-header=header-injection'
+        );
+    """
+    )).fetchone()
+
+    # Commit so background worker can start
+    sess.commit()
+
+    # Collect the response, waiting as needed
+    response = sess.execute(
+        text(
+            """
+        select * from net._http_collect_response(:request_id, async:=false);
+    """
+        ),
+        {"request_id": request_id},
+    ).fetchone()
+    assert response is not None
+    assert response[0] == "ERROR"
+    assert "Weird server reply" in response[1]
+
+
+def test_http_header_spaces(sess):
+    """Check that a `Spaces In Header Name: This header name contains spaces` header is processed correctly"""
+
+    (request_id,) = sess.execute(text(
+        """
+        select net.http_get(
+            url:='http://localhost:8080/pathological?malformed-header=spaces-in-header-name'
+        );
+    """
+    )).fetchone()
+
+    # Commit so background worker can start
+    sess.commit()
+
+    # Collect the response, waiting as needed
+    response = sess.execute(
+        text(
+            """
+        select * from net._http_collect_response(:request_id, async:=false);
+    """
+        ),
+        {"request_id": request_id},
+    ).fetchone()
+    assert response is not None
+    assert response[0] == "SUCCESS"
+    assert "Spaces In Header Name" in response[2]
+
+
+def test_http_header_non_printable_chars(sess):
+    """Check that a `NonPrintableChars: NonPrintableChars\\u0001\\u0002` header is processed correctly"""
+
+    (request_id,) = sess.execute(text(
+        """
+        select net.http_get(
+            url:='http://localhost:8080/pathological?malformed-header=non-printable-chars'
+        );
+    """
+    )).fetchone()
+
+    # Commit so background worker can start
+    sess.commit()
+
+    # Collect the response, waiting as needed
+    response = sess.execute(
+        text(
+            """
+        select * from net._http_collect_response(:request_id, async:=false);
+    """
+        ),
+        {"request_id": request_id},
+    ).fetchone()
+    assert response is not None
+    assert response[0] == "SUCCESS"
+    assert r"NonPrintableChars\\u0001\\u0002" in response[2]


### PR DESCRIPTION
When having a malformed header such as:

```
$ curl localhost:8080/pathological?malformed-header=header-injection -i
HTTP/1.1 200 OK
Server: nginx/1.26.0

HeaderInjection
Injected-Header: This header contains an injection
```

The background worker crashes.

To prove the above, we use https://github.com/steve-chavez/ngx_pathological.