### PR TITLE
feat: epoll based worker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --use-existing --inputdir=test
 
 MODULE_big = $(EXTENSION)
-OBJS = src/worker.o src/util.o
+OBJS = src/worker.o src/util.o src/core.o
 
 all: sql/$(EXTENSION)--$(EXTVERSION).sql $(EXTENSION).control
 

--- a/src/core.c
+++ b/src/core.c
@@ -1,0 +1,416 @@
+#include <postgres.h>
+#include <pgstat.h>
+#include <postmaster/bgworker.h>
+#include <storage/ipc.h>
+#include <storage/latch.h>
+#include <storage/proc.h>
+#include <fmgr.h>
+#include <access/xact.h>
+#include <executor/spi.h>
+#include <utils/snapmgr.h>
+#include <commands/extension.h>
+#include <catalog/pg_extension.h>
+#include <catalog/pg_type.h>
+#include <miscadmin.h>
+#include <utils/builtins.h>
+#include <access/hash.h>
+#include <utils/hsearch.h>
+#include <utils/memutils.h>
+#include <utils/jsonb.h>
+#include <utils/guc.h>
+#include <tcop/utility.h>
+
+#include <curl/curl.h>
+#include <curl/multi.h>
+
+#include <sys/epoll.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "util.h"
+#include "core.h"
+
+typedef struct {
+  int64 id;
+  StringInfo body;
+  struct curl_slist* request_headers;
+} CurlData;
+
+static size_t
+body_cb(void *contents, size_t size, size_t nmemb, void *userp)
+{
+  CurlData *cdata = (CurlData*) userp;
+  size_t realsize = size * nmemb;
+  appendBinaryStringInfo(cdata->body, (const char*)contents, (int)realsize);
+  return realsize;
+}
+
+static int multi_timer_cb(CURLM *multi, long timeout_ms, LoopState *lstate) {
+  elog(DEBUG2, "multi_timer_cb: Setting timeout to %ld ms\n", timeout_ms);
+
+  itimerspec its =
+    timeout_ms > 0 ?
+    // assign the timeout normally
+    (itimerspec){
+      .it_value.tv_sec = timeout_ms / 1000,
+      .it_value.tv_nsec = (timeout_ms % 1000) * 1000 * 1000,
+    }:
+    timeout_ms == 0 ?
+    /* libcurl wants us to timeout now, however setting both fields of
+     * new_value.it_value to zero disarms the timer. The closest we can
+     * do is to schedule the timer to fire in 1 ns. */
+    (itimerspec){
+      .it_value.tv_sec = 0,
+      .it_value.tv_nsec = 1,
+    }:
+     // libcurl passes a -1 to indicate the timer should be deleted
+    (itimerspec){};
+
+  int no_flags = 0;
+  if (timerfd_settime(lstate->timerfd, no_flags, &its, NULL) < 0) {
+    ereport(ERROR, errmsg("timerfd_settime failed"));
+  }
+
+  return 0;
+}
+
+static int multi_socket_cb(CURL *easy, curl_socket_t sockfd, int what, LoopState *lstate, void *socketp) {
+  static char *whatstrs[] = { "NONE", "CURL_POLL_IN", "CURL_POLL_OUT", "CURL_POLL_INOUT", "CURL_POLL_REMOVE" };
+  elog(DEBUG2, "multi_socket_cb: sockfd %d received %s", sockfd, whatstrs[what]);
+
+  int epoll_op;
+  if(!socketp){
+    epoll_op = EPOLL_CTL_ADD;
+    bool *socket_exists = palloc(sizeof(bool));
+    curl_multi_assign(lstate->curl_mhandle, sockfd, socket_exists);
+  } else if (what == CURL_POLL_REMOVE){
+    epoll_op = EPOLL_CTL_DEL;
+    pfree(socketp);
+    curl_multi_assign(lstate->curl_mhandle, sockfd, NULL);
+  } else {
+    epoll_op = EPOLL_CTL_MOD;
+  }
+
+  epoll_event ev = {
+    .data.fd = sockfd,
+    .events =
+      (what & CURL_POLL_IN) ?
+      EPOLLIN:
+      (what & CURL_POLL_OUT) ?
+      EPOLLOUT:
+      0, // no event is assigned since here we get CURL_POLL_REMOVE and the sockfd will be removed
+  };
+
+  // epoll_ctl will copy ev, so there's no need to do palloc for the epoll_event
+  // https://github.com/torvalds/linux/blob/e32cde8d2bd7d251a8f9b434143977ddf13dcec6/fs/eventpoll.c#L2408-L2418
+  if (epoll_ctl(lstate->epfd, epoll_op, sockfd, &ev) < 0) {
+    int e = errno;
+    static char *opstrs[] = { "NONE", "EPOLL_CTL_ADD", "EPOLL_CTL_DEL", "EPOLL_CTL_MOD" };
+    ereport(ERROR, errmsg("epoll_ctl with %s failed when receiving %s for sockfd %d: %s", whatstrs[what], opstrs[epoll_op], sockfd, strerror(e)));
+  }
+
+  return 0;
+}
+
+// We need a different memory context here, as the parent function will have an SPI memory context, which has a shorter lifetime.
+static void init_curl_handle(CURLM *curl_mhandle, MemoryContext curl_memctx, int64 id, Datum urlBin, NullableDatum bodyBin, NullableDatum headersBin, Datum methodBin, int32 timeout_milliseconds){
+  MemoryContext old_ctx = MemoryContextSwitchTo(curl_memctx);
+
+  CurlData *cdata = palloc(sizeof(CurlData));
+  cdata->id   = id;
+  cdata->body = makeStringInfo();
+
+  if (!headersBin.isnull) {
+    ArrayType *pgHeaders = DatumGetArrayTypeP(headersBin.value);
+    struct curl_slist *request_headers = NULL;
+
+    request_headers = pg_text_array_to_slist(pgHeaders, request_headers);
+
+    CURL_SLIST_APPEND(request_headers, "User-Agent: pg_net/" EXTVERSION);
+
+    cdata->request_headers = request_headers;
+  }
+
+  char *url = TextDatumGetCString(urlBin);
+
+  char *reqBody = !bodyBin.isnull ? TextDatumGetCString(bodyBin.value) : NULL;
+
+  char *method = TextDatumGetCString(methodBin);
+  if (strcasecmp(method, "GET") != 0 && strcasecmp(method, "POST") != 0 && strcasecmp(method, "DELETE") != 0) {
+    ereport(ERROR, errmsg("Unsupported request method %s", method));
+  }
+
+  CURL *curl_ez_handle = curl_easy_init();
+  if(!curl_ez_handle)
+    ereport(ERROR, errmsg("curl_easy_init()"));
+
+  if (strcasecmp(method, "GET") == 0) {
+    if (reqBody) {
+      CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_POSTFIELDS, reqBody);
+      CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_CUSTOMREQUEST, "GET");
+    }
+  }
+
+  if (strcasecmp(method, "POST") == 0) {
+    if (reqBody) {
+      CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_POSTFIELDS, reqBody);
+    }
+    else {
+      CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_POST, 1);
+      CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_POSTFIELDSIZE, 0);
+    }
+  }
+
+  if (strcasecmp(method, "DELETE") == 0) {
+    CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_CUSTOMREQUEST, "DELETE");
+  }
+
+  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_WRITEFUNCTION, body_cb);
+  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_WRITEDATA, cdata);
+  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_HEADER, 0L);
+  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_URL, url);
+  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_HTTPHEADER, cdata->request_headers);
+  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_TIMEOUT_MS, timeout_milliseconds);
+  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_PRIVATE, cdata);
+  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_FOLLOWLOCATION, true);
+  if (log_min_messages <= DEBUG2)
+    CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_VERBOSE, 1L);
+#if LIBCURL_VERSION_NUM >= 0x075500 /* libcurl 7.85.0 */
+  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_PROTOCOLS_STR, "http,https");
+#else
+  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
+#endif
+
+  EREPORT_MULTI(
+    curl_multi_add_handle(curl_mhandle, curl_ez_handle)
+  );
+
+  MemoryContextSwitchTo(old_ctx);
+}
+
+void set_curl_mhandle(CURLM *curl_mhandle, LoopState *lstate){
+  CURL_MULTI_SETOPT(curl_mhandle, CURLMOPT_SOCKETFUNCTION, multi_socket_cb);
+  CURL_MULTI_SETOPT(curl_mhandle, CURLMOPT_SOCKETDATA, lstate);
+  CURL_MULTI_SETOPT(curl_mhandle, CURLMOPT_TIMERFUNCTION, multi_timer_cb);
+  CURL_MULTI_SETOPT(curl_mhandle, CURLMOPT_TIMERDATA, lstate);
+}
+
+void delete_expired_responses(char *ttl, int batch_size){
+  SetCurrentStatementStartTimestamp();
+  StartTransactionCommand();
+  PushActiveSnapshot(GetTransactionSnapshot());
+  SPI_connect();
+
+  int ret_code = SPI_execute_with_args("\
+    WITH\
+    rows AS (\
+      SELECT ctid\
+      FROM net._http_response\
+      WHERE created < now() - $1\
+      ORDER BY created\
+      LIMIT $2\
+    )\
+    DELETE FROM net._http_response r\
+    USING rows WHERE r.ctid = rows.ctid",
+    2,
+    (Oid[]){INTERVALOID, INT4OID},
+    (Datum[]){
+      DirectFunctionCall3(interval_in, CStringGetDatum(ttl), ObjectIdGetDatum(InvalidOid), Int32GetDatum(-1))
+    , Int32GetDatum(batch_size)
+    }, NULL, false, 0);
+
+  if (ret_code != SPI_OK_DELETE)
+  {
+    ereport(ERROR, errmsg("Error expiring response table rows: %s", SPI_result_code_string(ret_code)));
+  }
+
+  SPI_finish();
+  PopActiveSnapshot();
+  CommitTransactionCommand();
+}
+
+static void insert_failure_response(CURLcode return_code, int64 id){
+  StartTransactionCommand();
+  PushActiveSnapshot(GetTransactionSnapshot());
+  SPI_connect();
+
+  int ret_code = SPI_execute_with_args("\
+      insert into net._http_response(id, error_msg) values ($1, $2)",
+      2,
+      (Oid[]){INT8OID, CSTRINGOID},
+      (Datum[]){Int64GetDatum(id), CStringGetDatum(curl_easy_strerror(return_code))},
+      NULL, false, 1);
+
+  if (ret_code != SPI_OK_INSERT)
+  {
+    ereport(ERROR, errmsg("Error when inserting failed response: %s", SPI_result_code_string(ret_code)));
+  }
+
+  SPI_finish();
+  PopActiveSnapshot();
+  CommitTransactionCommand();
+}
+
+static void insert_success_response(CurlData *cdata, long http_status_code, char *contentType, Jsonb *jsonb_headers){
+  StartTransactionCommand();
+  PushActiveSnapshot(GetTransactionSnapshot());
+  SPI_connect();
+
+  int ret_code = SPI_execute_with_args("\
+      insert into net._http_response(id, status_code, content, headers, content_type, timed_out) values ($1, $2, $3, $4, $5, $6)",
+      6,
+      (Oid[]){INT8OID, INT4OID, CSTRINGOID, JSONBOID, CSTRINGOID, BOOLOID},
+      (Datum[]){
+        Int64GetDatum(cdata->id)
+      , Int32GetDatum(http_status_code)
+      , CStringGetDatum(cdata->body->data)
+      , JsonbPGetDatum(jsonb_headers)
+      , CStringGetDatum(contentType)
+      , BoolGetDatum(false) // timed_out is false here as it's a success
+      },
+      (char[6]){
+        ' '
+      , [2] = cdata->body->data[0] == '\0'? 'n' : ' '
+      , [4] = !contentType? 'n' :' '
+      },
+      false, 1);
+
+  if (ret_code != SPI_OK_INSERT)
+  {
+    ereport(ERROR, errmsg("Error when inserting successful response: %s", SPI_result_code_string(ret_code)));
+  }
+
+  SPI_finish();
+  PopActiveSnapshot();
+  CommitTransactionCommand();
+}
+
+void consume_request_queue(CURLM *curl_mhandle, int batch_size, MemoryContext curl_memctx){
+  StartTransactionCommand();
+  PushActiveSnapshot(GetTransactionSnapshot());
+  SPI_connect();
+
+  int ret_code = SPI_execute_with_args("\
+    WITH\
+    rows AS (\
+      SELECT id\
+      FROM net.http_request_queue\
+      ORDER BY id\
+      LIMIT $1\
+    )\
+    DELETE FROM net.http_request_queue q\
+    USING rows WHERE q.id = rows.id\
+    RETURNING q.id, q.method, q.url, timeout_milliseconds, array(select key || ': ' || value from jsonb_each_text(q.headers)), q.body",
+    1,
+    (Oid[]){INT4OID},
+    (Datum[]){Int32GetDatum(batch_size)},
+    NULL, false, 0);
+
+  if (ret_code != SPI_OK_DELETE_RETURNING)
+    ereport(ERROR, errmsg("Error getting http request queue: %s", SPI_result_code_string(ret_code)));
+
+
+  for (int j = 0; j < SPI_processed; j++) {
+    bool tupIsNull = false;
+
+    int64 id = DatumGetInt64(SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 1, &tupIsNull));
+    EREPORT_NULL_ATTR(tupIsNull, id);
+
+    int32 timeout_milliseconds = DatumGetInt32(SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 4, &tupIsNull));
+    EREPORT_NULL_ATTR(tupIsNull, timeout_milliseconds);
+
+    Datum method = SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 2, &tupIsNull);
+    EREPORT_NULL_ATTR(tupIsNull, method);
+
+    Datum url = SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 3, &tupIsNull);
+    EREPORT_NULL_ATTR(tupIsNull, url);
+
+    NullableDatum headersBin = {
+      .value = SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 5, &tupIsNull),
+      .isnull = tupIsNull
+    };
+
+    NullableDatum bodyBin = {
+      .value = SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 6, &tupIsNull),
+      .isnull = tupIsNull
+    };
+
+    init_curl_handle(curl_mhandle, curl_memctx, id, url, bodyBin, headersBin, method, timeout_milliseconds);
+  }
+
+  SPI_finish();
+  PopActiveSnapshot();
+  CommitTransactionCommand();
+}
+
+static void pfree_curl_data(CurlData *cdata){
+  pfree(cdata->body->data);
+  pfree(cdata->body);
+  if(cdata->request_headers) //curl_slist_free_all already handles the NULL case, but be explicit about it
+    curl_slist_free_all(cdata->request_headers);
+}
+
+static Jsonb *jsonb_headers_from_curl_handle(CURL *ez_handle){
+  struct curl_header *header, *prev = NULL;
+
+  JsonbParseState *headers = NULL;
+  (void)pushJsonbValue(&headers, WJB_BEGIN_OBJECT, NULL);
+
+  while((header = curl_easy_nextheader(ez_handle, CURLH_HEADER, 0, prev))) {
+    JsonbValue key   = {.type = jbvString, .val = {.string = {.val = header->name,  .len = strlen(header->name)}}};
+    JsonbValue value = {.type = jbvString, .val = {.string = {.val = header->value, .len = strlen(header->value)}}};
+    (void)pushJsonbValue(&headers, WJB_KEY,   &key);
+    (void)pushJsonbValue(&headers, WJB_VALUE, &value);
+    prev = header;
+  }
+
+  Jsonb *jsonb_headers = JsonbValueToJsonb(pushJsonbValue(&headers, WJB_END_OBJECT, NULL));
+
+  return jsonb_headers;
+}
+
+// Switch back to the curl memory context, which has the curl handles stored
+void insert_curl_responses(LoopState *lstate, MemoryContext curl_memctx){
+  MemoryContext old_ctx = MemoryContextSwitchTo(curl_memctx);
+  int msgs_left=0;
+  CURLMsg *msg = NULL;
+  CURLM *curl_mhandle = lstate->curl_mhandle;
+
+  while ((msg = curl_multi_info_read(curl_mhandle, &msgs_left))) {
+    if (msg->msg == CURLMSG_DONE) {
+      CURLcode return_code = msg->data.result;
+      CURL *ez_handle= msg->easy_handle;
+      CurlData *cdata = NULL;
+      CURL_EZ_GETINFO(ez_handle, CURLINFO_PRIVATE, &cdata);
+
+      if (return_code != CURLE_OK) {
+        insert_failure_response(return_code, cdata->id);
+      } else {
+        char *contentType;
+        CURL_EZ_GETINFO(ez_handle, CURLINFO_CONTENT_TYPE, &contentType);
+
+        long http_status_code;
+        CURL_EZ_GETINFO(ez_handle, CURLINFO_RESPONSE_CODE, &http_status_code);
+
+        Jsonb *jsonb_headers = jsonb_headers_from_curl_handle(ez_handle);
+
+        insert_success_response(cdata, http_status_code, contentType, jsonb_headers);
+
+        pfree_curl_data(cdata);
+      }
+
+      int res = curl_multi_remove_handle(curl_mhandle, ez_handle);
+      if(res != CURLM_OK)
+        ereport(ERROR, errmsg("curl_multi_remove_handle: %s", curl_multi_strerror(res)));
+
+      curl_easy_cleanup(ez_handle);
+    } else {
+      ereport(ERROR, errmsg("curl_multi_info_read(), CURLMsg=%d\n", msg->msg));
+    }
+  }
+
+  MemoryContextSwitchTo(old_ctx);
+}

--- a/src/core.h
+++ b/src/core.h
@@ -1,0 +1,21 @@
+#ifndef CORE_H
+#define CORE_H
+
+typedef struct itimerspec itimerspec;
+typedef struct epoll_event epoll_event;
+
+typedef struct {
+  int epfd;
+  int timerfd;
+  CURLM *curl_mhandle;
+} LoopState;
+
+void delete_expired_responses(char *ttl, int batch_size);
+
+void consume_request_queue(CURLM *curl_mhandle, int batch_size, MemoryContext curl_memctx);
+
+void insert_curl_responses(LoopState *lstate, MemoryContext curl_memctx);
+
+void set_curl_mhandle(CURLM *curl_mhandle, LoopState *lstate);
+
+#endif

--- a/src/util.c
+++ b/src/util.c
@@ -2,6 +2,7 @@
 
 #include <tcop/utility.h>
 #include <utils/builtins.h>
+#include <utils/jsonb.h>
 
 #include <curl/curl.h>
 

--- a/src/util.h
+++ b/src/util.h
@@ -13,6 +13,12 @@
         ereport(ERROR, errmsg("Could not curl_easy_getinfo(%s)", #opt)); \
   } while (0)
 
+#define CURL_MULTI_SETOPT(hdl, opt, prm) \
+  do { \
+      if (curl_multi_setopt(hdl, opt, prm) != CURLM_OK) \
+        ereport(ERROR, errmsg("Could not curl_multi_setopt(%s)", #opt)); \
+  } while (0)
+
 #define CURL_SLIST_APPEND(list, str) \
   do { \
     struct curl_slist *new_list = curl_slist_append(list, str); \
@@ -27,6 +33,12 @@
       ereport(ERROR, errmsg("%s cannot be null", #attr)); \
   } while (0)
 
+#define EREPORT_MULTI(multi_call) \
+  do { \
+    CURLMcode code = multi_call; \
+    if (code != CURLM_OK) \
+      ereport(ERROR, errmsg("%s failed with %s", #multi_call, curl_multi_strerror(code))); \
+  } while (0)
 
 extern struct curl_slist *pg_text_array_to_slist(ArrayType *array,
                                                  struct curl_slist *headers);

--- a/src/worker.c
+++ b/src/worker.c
@@ -23,27 +23,32 @@
 #include <curl/curl.h>
 #include <curl/multi.h>
 
+#include <sys/epoll.h>
+#include <sys/timerfd.h>
+#include <unistd.h>
+#include <errno.h>
+#include <string.h>
+#include <inttypes.h>
+
 #include "util.h"
+#include "core.h"
 
 #define MIN_LIBCURL_VERSION_NUM 0x075300 // This is the 7.83.0 version in hex as defined in curl/curlver.h
-_Static_assert(LIBCURL_VERSION_NUM, "libcurl >= 7.83.0 is required"); // test for older libcurl versions that don't even have LIBCURL_VERSION_NUM defined (e.g. libcurl 6.5).
-_Static_assert(LIBCURL_VERSION_NUM >= MIN_LIBCURL_VERSION_NUM, "libcurl >= 7.83.0 is required");
+#define REQUIRED_LIBCURL_ERR_MSG "libcurl >= 7.83.0 is required, we use the curl_easy_nextheader() function added in this version"
+_Static_assert(LIBCURL_VERSION_NUM, REQUIRED_LIBCURL_ERR_MSG); // test for older libcurl versions that don't even have LIBCURL_VERSION_NUM defined (e.g. libcurl 6.5).
+_Static_assert(LIBCURL_VERSION_NUM >= MIN_LIBCURL_VERSION_NUM, REQUIRED_LIBCURL_ERR_MSG);
 
 PG_MODULE_MAGIC;
 
 static char *guc_ttl;
 static int guc_batch_size;
 static char* guc_database_name;
+static MemoryContext CurlMemContext = NULL;
 
 void _PG_init(void);
 PGDLLEXPORT void pg_net_worker(Datum main_arg) pg_attribute_noreturn();
 
-typedef struct {
-  int64 id;
-  StringInfo body;
-  struct curl_slist* request_headers;
-} CurlData;
-
+static long latch_timeout = 1000;
 static volatile sig_atomic_t got_sigterm = false;
 static volatile sig_atomic_t got_sighup = false;
 
@@ -67,285 +72,16 @@ handle_sighup(SIGNAL_ARGS)
   errno = save_errno;
 }
 
-static size_t
-body_cb(void *contents, size_t size, size_t nmemb, void *userp)
-{
-  size_t realsize = size * nmemb;
-  StringInfo si = (StringInfo)userp;
-  appendBinaryStringInfo(si, (const char*)contents, (int)realsize);
-  return realsize;
-}
-
 static bool is_extension_loaded(){
   Oid extensionOid;
 
   StartTransactionCommand();
+
   extensionOid = get_extension_oid("pg_net", true);
+
   CommitTransactionCommand();
 
   return OidIsValid(extensionOid);
-}
-
-static void delete_expired_responses(char *ttl){
-  int ret_code = SPI_execute_with_args("\
-    WITH\
-    rows AS (\
-      SELECT ctid\
-      FROM net._http_response\
-      WHERE created < now() - $1\
-      ORDER BY created\
-      LIMIT $2\
-    )\
-    DELETE FROM net._http_response r\
-    USING rows WHERE r.ctid = rows.ctid",
-    2,
-    (Oid[]){INTERVALOID, INT4OID},
-    (Datum[]){
-      DirectFunctionCall3(interval_in, CStringGetDatum(ttl), ObjectIdGetDatum(InvalidOid), Int32GetDatum(-1))
-    , Int32GetDatum(guc_batch_size)
-    }, NULL, false, 0);
-
-  if (ret_code != SPI_OK_DELETE)
-  {
-    ereport(ERROR, errmsg("Error expiring response table rows: %s", SPI_result_code_string(ret_code)));
-  }
-}
-
-static void insert_failure_response(CURLcode return_code, int64 id){
-  int ret_code = SPI_execute_with_args("\
-      insert into net._http_response(id, error_msg) values ($1, $2)",
-      2,
-      (Oid[]){INT8OID, CSTRINGOID},
-      (Datum[]){Int64GetDatum(id), CStringGetDatum(curl_easy_strerror(return_code))},
-      NULL, false, 1);
-
-  if (ret_code != SPI_OK_INSERT)
-  {
-    ereport(ERROR, errmsg("Error when inserting failed response: %s", SPI_result_code_string(ret_code)));
-  }
-}
-
-static void insert_success_response(CurlData *cdata, long http_status_code, char *contentType, Jsonb *jsonb_headers){
-  int ret_code = SPI_execute_with_args("\
-      insert into net._http_response(id, status_code, content, headers, content_type, timed_out) values ($1, $2, $3, $4, $5, $6)",
-      6,
-      (Oid[]){INT8OID, INT4OID, CSTRINGOID, JSONBOID, CSTRINGOID, BOOLOID},
-      (Datum[]){
-        Int64GetDatum(cdata->id)
-      , Int32GetDatum(http_status_code)
-      , CStringGetDatum(cdata->body->data)
-      , JsonbPGetDatum(jsonb_headers)
-      , CStringGetDatum(contentType)
-      , BoolGetDatum(false) // timed_out is false here as it's a success
-      },
-      (char[6]){
-        ' '
-      , [2] = cdata->body->data[0] == '\0'? 'n' : ' '
-      , [4] = !contentType? 'n' :' '
-      },
-      false, 1);
-
-  if ( ret_code != SPI_OK_INSERT)
-  {
-    ereport(ERROR, errmsg("Error when inserting successful response: %s", SPI_result_code_string(ret_code)));
-  }
-}
-
-static void pfree_curl_data(CurlData *cdata){
-  pfree(cdata->body->data);
-  pfree(cdata->body);
-  if(cdata->request_headers) //curl_slist_free_all already handles the NULL case, but be explicit about it
-    curl_slist_free_all(cdata->request_headers);
-  pfree(cdata);
-}
-
-static void init_curl_handle(CURLM *curl_mhandle, CurlData *cdata, char *url, char *reqBody, char *method, int32 timeout_milliseconds){
-  CURL *curl_ez_handle = curl_easy_init();
-  if(!curl_ez_handle)
-    ereport(ERROR, errmsg("curl_easy_init()"));
-
-  if (strcasecmp(method, "GET") == 0) {
-    if (reqBody) {
-      CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_POSTFIELDS, reqBody);
-      CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_CUSTOMREQUEST, "GET");
-    }
-  }
-
-  if (strcasecmp(method, "POST") == 0) {
-    if (reqBody) {
-      CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_POSTFIELDS, reqBody);
-    }
-    else {
-      CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_POST, 1);
-      CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_POSTFIELDSIZE, 0);
-    }
-  }
-
-  if (strcasecmp(method, "DELETE") == 0) {
-    CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_CUSTOMREQUEST, "DELETE");
-  }
-
-  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_WRITEFUNCTION, body_cb);
-  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_WRITEDATA, cdata->body);
-  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_HEADER, 0L);
-  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_URL, url);
-  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_HTTPHEADER, cdata->request_headers);
-  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_TIMEOUT_MS, timeout_milliseconds);
-  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_PRIVATE, cdata);
-  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_FOLLOWLOCATION, true);
-  if (log_min_messages <= DEBUG2)
-    CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_VERBOSE, 1L);
-#if LIBCURL_VERSION_NUM >= 0x075500 /* libcurl 7.85.0 */
-  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_PROTOCOLS_STR, "http,https");
-#else
-  CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_PROTOCOLS, CURLPROTO_HTTP | CURLPROTO_HTTPS);
-#endif
-
-  CURLMcode code = curl_multi_add_handle(curl_mhandle, curl_ez_handle);
-  if(code != CURLM_OK)
-    ereport(ERROR, errmsg("curl_multi_add_handle returned %s", curl_multi_strerror(code)));
-}
-
-static void consume_request_queue(CURLM *curl_mhandle){
-  int ret_code = SPI_execute_with_args("\
-    WITH\
-    rows AS (\
-      SELECT id\
-      FROM net.http_request_queue\
-      ORDER BY id\
-      LIMIT $1\
-    )\
-    DELETE FROM net.http_request_queue q\
-    USING rows WHERE q.id = rows.id\
-    RETURNING q.id, q.method, q.url, timeout_milliseconds, array(select key || ': ' || value from jsonb_each_text(q.headers)), q.body",
-    1,
-    (Oid[]){INT4OID},
-    (Datum[]){Int32GetDatum(guc_batch_size)},
-    NULL, false, 0);
-
-  if (ret_code != SPI_OK_DELETE_RETURNING)
-    ereport(ERROR, errmsg("Error getting http request queue: %s", SPI_result_code_string(ret_code)));
-
-  for (int j = 0; j < SPI_processed; j++) {
-    bool tupIsNull = false;
-
-    int64 id = DatumGetInt64(SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 1, &tupIsNull));
-    EREPORT_NULL_ATTR(tupIsNull, id);
-
-    char *method = TextDatumGetCString(SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 2, &tupIsNull));
-    EREPORT_NULL_ATTR(tupIsNull, method);
-
-    char *url = TextDatumGetCString(SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 3, &tupIsNull));
-    EREPORT_NULL_ATTR(tupIsNull, url);
-
-    int32 timeout_milliseconds = DatumGetInt32(SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 4, &tupIsNull));
-    EREPORT_NULL_ATTR(tupIsNull, timeout_milliseconds);
-
-    if (strcasecmp(method, "GET") != 0 && strcasecmp(method, "POST") != 0 && strcasecmp(method, "DELETE") != 0) {
-      ereport(ERROR, errmsg("Unsupported request method %s", method));
-    }
-
-    CurlData *cdata = palloc(sizeof(CurlData));
-
-    Datum headersBin = SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 5, &tupIsNull);
-
-    if (!tupIsNull) {
-      ArrayType *pgHeaders = DatumGetArrayTypeP(headersBin);
-      struct curl_slist *request_headers = NULL;
-
-      request_headers = pg_text_array_to_slist(pgHeaders, request_headers);
-
-      CURL_SLIST_APPEND(request_headers, "User-Agent: pg_net/" EXTVERSION);
-
-      cdata->request_headers = request_headers;
-    }
-
-    char *reqBody = NULL;
-    Datum bodyBin = SPI_getbinval(SPI_tuptable->vals[j], SPI_tuptable->tupdesc, 6, &tupIsNull);
-    if (!tupIsNull) reqBody = TextDatumGetCString(bodyBin);
-
-    cdata->body = makeStringInfo();
-    cdata->id = id;
-
-    init_curl_handle(curl_mhandle, cdata, url, reqBody, method, timeout_milliseconds);
-  }
-}
-
-static Jsonb *jsonb_headers_from_curl_handle(CURL *ez_handle){
-  struct curl_header *header, *prev = NULL;
-
-  JsonbParseState *headers = NULL;
-  (void)pushJsonbValue(&headers, WJB_BEGIN_OBJECT, NULL);
-
-  while((header = curl_easy_nextheader(ez_handle, CURLH_HEADER, 0, prev))) {
-    JsonbValue key   = {.type = jbvString, .val = {.string = {.val = header->name,  .len = strlen(header->name)}}};
-    JsonbValue value = {.type = jbvString, .val = {.string = {.val = header->value, .len = strlen(header->value)}}};
-    (void)pushJsonbValue(&headers, WJB_KEY,   &key);
-    (void)pushJsonbValue(&headers, WJB_VALUE, &value);
-    prev = header;
-  }
-
-  Jsonb *jsonb_headers = JsonbValueToJsonb(pushJsonbValue(&headers, WJB_END_OBJECT, NULL));
-
-  return jsonb_headers;
-}
-
-static void insert_curl_responses(CURLM *curl_mhandle){
-  int still_running = 0;
-
-  do {
-    int numfds = 0;
-
-    int res = curl_multi_perform(curl_mhandle, &still_running);
-
-    if(res != CURLM_OK) {
-      ereport(ERROR, errmsg("error: curl_multi_perform() returned %d", res));
-    }
-
-    /*wait at least 1 second(1000 ms) in case all responses are slow*/
-    /*this avoids busy waiting and higher CPU usage*/
-    res = curl_multi_wait(curl_mhandle, NULL, 0, 1000, &numfds);
-
-    if(res != CURLM_OK) {
-      ereport(ERROR, errmsg("error: curl_multi_wait() returned %d", res));
-    }
-  } while(still_running);
-
-  int msgs_left=0;
-  CURLMsg *msg = NULL;
-
-  while ((msg = curl_multi_info_read(curl_mhandle, &msgs_left))) {
-    if (msg->msg == CURLMSG_DONE) {
-      CURLcode return_code = msg->data.result;
-      CURL *ez_handle= msg->easy_handle;
-      CurlData *cdata = NULL;
-      CURL_EZ_GETINFO(ez_handle, CURLINFO_PRIVATE, &cdata);
-
-      if (return_code != CURLE_OK) {
-        insert_failure_response(return_code, cdata->id);
-      } else {
-        char *contentType;
-        CURL_EZ_GETINFO(ez_handle, CURLINFO_CONTENT_TYPE, &contentType);
-
-        long http_status_code;
-        CURL_EZ_GETINFO(ez_handle, CURLINFO_RESPONSE_CODE, &http_status_code);
-
-        Jsonb *jsonb_headers = jsonb_headers_from_curl_handle(ez_handle);
-
-        insert_success_response(cdata, http_status_code, contentType, jsonb_headers);
-
-        pfree_curl_data(cdata);
-      }
-
-      int res = curl_multi_remove_handle(curl_mhandle, ez_handle);
-      if(res != CURLM_OK)
-        ereport(ERROR, errmsg("curl_multi_remove_handle: %s", curl_multi_strerror(res)));
-
-      curl_easy_cleanup(ez_handle);
-    } else {
-      ereport(ERROR, errmsg("curl_multi_info_read(), CURLMsg=%d\n", msg->msg));
-    }
-  }
 }
 
 void pg_net_worker(Datum main_arg) {
@@ -363,11 +99,33 @@ void pg_net_worker(Datum main_arg) {
   if(curl_ret != CURLE_OK)
     ereport(ERROR, errmsg("curl_global_init() returned %s\n", curl_easy_strerror(curl_ret)));
 
-  while (!got_sigterm)
-  {
+  LoopState lstate = {
+    .epfd = epoll_create1(0),
+    .timerfd = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC),
+    .curl_mhandle = curl_multi_init(),
+  };
+
+  if (lstate.epfd < 0) {
+    ereport(ERROR, errmsg("Failed to create epoll file descriptor"));
+  }
+
+  if (lstate.timerfd < 0) {
+    ereport(ERROR, errmsg("Failed to create timerfd"));
+  }
+
+  if(!lstate.curl_mhandle)
+    ereport(ERROR, errmsg("curl_multi_init()"));
+
+  set_curl_mhandle(lstate.curl_mhandle, &lstate);
+
+  timerfd_settime(lstate.timerfd, 0, &(itimerspec){}, NULL);
+
+  epoll_ctl(lstate.epfd, EPOLL_CTL_ADD, lstate.timerfd, &(epoll_event){.events = EPOLLIN, .data.fd = lstate.timerfd});
+
+  while (!got_sigterm) {
     WaitLatch(&MyProc->procLatch,
           WL_LATCH_SET | WL_TIMEOUT | WL_EXIT_ON_PM_DEATH,
-          1000L,
+          latch_timeout,
           PG_WAIT_EXTENSION);
     ResetLatch(&MyProc->procLatch);
 
@@ -383,28 +141,66 @@ void pg_net_worker(Datum main_arg) {
       ProcessConfigFile(PGC_SIGHUP);
     }
 
-    SetCurrentStatementStartTimestamp();
-    StartTransactionCommand();
-    PushActiveSnapshot(GetTransactionSnapshot());
-    SPI_connect();
+    delete_expired_responses(guc_ttl, guc_batch_size);
 
-    delete_expired_responses(guc_ttl);
+    consume_request_queue(lstate.curl_mhandle, guc_batch_size, CurlMemContext);
 
-    CURLM *curl_mhandle = curl_multi_init();
-    if(!curl_mhandle)
-      ereport(ERROR, errmsg("curl_multi_init()"));
+    int running_handles = 0;
+    int maxevents = guc_batch_size + 1; // 1 extra for the timer
+    epoll_event *events = palloc0(sizeof(epoll_event) * maxevents);
 
-    consume_request_queue(curl_mhandle);
-    insert_curl_responses(curl_mhandle);
+    do {
+      int nfds = epoll_wait(lstate.epfd, events, maxevents, /*timeout=*/1000);
+      if (nfds < 0) {
+        int save_errno = errno;
+        if(save_errno == EINTR) { // can happen when the epoll is interrupted, for example when running under GDB. Just continue in this case.
+          continue;
+        }
+        else {
+          ereport(ERROR, errmsg("epoll_wait() failed: %s", strerror(save_errno)));
+          break;
+        }
+      }
 
-    curl_ret = curl_multi_cleanup(curl_mhandle);
-    if(curl_ret != CURLM_OK)
-      ereport(ERROR, errmsg("curl_multi_cleanup: %s", curl_multi_strerror(curl_ret)));
+      for (int i = 0; i < nfds; i++) {
+        if (events[i].data.fd == lstate.timerfd) {
+          EREPORT_MULTI(
+            curl_multi_socket_action(lstate.curl_mhandle, CURL_SOCKET_TIMEOUT, 0, &running_handles)
+          );
+        } else {
+          int ev_bitmask =
+            events[i].events & EPOLLIN ? CURL_CSELECT_IN:
+            events[i].events & EPOLLOUT ? CURL_CSELECT_OUT:
+            CURL_CSELECT_ERR;
 
-    SPI_finish();
-    PopActiveSnapshot();
-    CommitTransactionCommand();
+          EREPORT_MULTI(
+            curl_multi_socket_action(
+              lstate.curl_mhandle, events[i].data.fd,
+              ev_bitmask,
+              &running_handles)
+          );
+
+          if(running_handles <= 0) {
+            elog(DEBUG2, "last transfer done, kill timeout");
+            timerfd_settime(lstate.timerfd, 0, &(itimerspec){0}, NULL);
+          }
+        }
+
+        insert_curl_responses(&lstate, CurlMemContext);
+      }
+
+    } while (running_handles > 0); // run again while there are curl handles, this will prevent waiting for the latch_timeout (which will cause the cause the curl timeouts to be wrong)
+
+    pfree(events);
+
+    MemoryContextReset(CurlMemContext);
   }
+
+  close(lstate.epfd);
+  close(lstate.timerfd);
+
+  curl_multi_cleanup(lstate.curl_mhandle);
+  curl_global_cleanup();
 
   // causing a failure on exit will make the postmaster process restart the bg worker
   proc_exit(EXIT_FAILURE);
@@ -429,6 +225,12 @@ void _PG_init(void) {
     .bgw_name = "pg_net " EXTVERSION " worker",
     .bgw_restart_time = 1,
   });
+
+  CurlMemContext = AllocSetContextCreate(TopMemoryContext,
+                       "pg_net curl context",
+                       ALLOCSET_DEFAULT_MINSIZE,
+                       ALLOCSET_DEFAULT_INITSIZE,
+                       ALLOCSET_DEFAULT_MAXSIZE);
 
   DefineCustomStringVariable("pg_net.ttl",
                  "time to live for request/response rows",


### PR DESCRIPTION
This replaces the usage of [curl_multi_perform](https://curl.se/libcurl/c/curl_multi_perform.html) (which uses `select()`) for [curl_multi_socket_action](https://curl.se/libcurl/c/curl_multi_socket_action.html) + `epoll()`, which is more performant (requests finish in less time) and more reliable (with 0 timeouts). 

It solves #86. Using the cloud test added on https://github.com/supabase/pg_net/pull/150, on this branch we get the following results:

```
postgres=# call repro_timeouts(10000);
NOTICE:  Waiting until 10000 requests complete
NOTICE:  Stats: {"request_successes":10000,"request_failures":0,"last_failure_error":null}
NOTICE:  Time taken: 00:01:01.360567
CALL

postgres=# call repro_timeouts(20000);
NOTICE:  Waiting until 20000 requests complete
NOTICE:  Stats: {"request_successes":20000,"request_failures":0,"last_failure_error":null}
NOTICE:  Time taken: 00:01:44.942479

postgres=# call repro_timeouts(100000);
NOTICE:  Waiting until 100000 requests complete
NOTICE:  Stats: {"request_successes":100000,"request_failures":0,"last_failure_error":null}
NOTICE:  Time taken: 00:08:58.325675

postgres=# call repro_timeouts (1000000);
NOTICE:  Waiting until 1000000 requests complete
NOTICE:  Stats: {"request_successes":1000000,"request_failures":0,"last_failure_error":null}
NOTICE:  Time taken: 01:45:33.085331
CALL
```

On master:

```
postgres=# call repro_timeouts(10000);
NOTICE:  Waiting until 10000 requests complete
NOTICE:  Stats: {"request_successes":8886,"request_failures":1114,"last_failure_error":"Ti
meout was reached"}
NOTICE:  Time taken: 00:01:44.061517
CALL
postgres=# call repro_timeouts(20000);
NOTICE:  Waiting until 20000 requests complete
NOTICE:  Stats: {"request_successes":18071,"request_failures":1929,"last_failure_error":"T
imeout was reached"}
NOTICE:  Time taken: 00:04:05.716657
CALL

postgres=# call repro_timeouts(30000);
NOTICE:  Waiting until 30000 requests complete
NOTICE:  Stats: {"request_successes":26939,"request_failures":3061,"last_failure_error":"T
imeout was reached"}
NOTICE:  Time taken: 00:06:31.642828
CALL
```

So we get 0 timeouts on 1M requests, while on master we got many failures starting at 10K requests. The completion of the requests take much less time as well.