### PR TITLE
feat: make ttl & batch_size SUSET

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -434,7 +434,7 @@ _PG_init(void)
                  "should be a valid interval type",
                  &guc_ttl,
                  "6 hours",
-                 PGC_SIGHUP, 0,
+                 PGC_SUSET, 0,
                  NULL, NULL, NULL);
 
   DefineCustomIntVariable("pg_net.batch_size",
@@ -443,7 +443,7 @@ _PG_init(void)
                  &guc_batch_size,
                  200,
                  0, PG_INT16_MAX,
-                 PGC_SIGHUP, 0,
+                 PGC_SUSET, 0,
                  NULL, NULL, NULL);
 
   DefineCustomStringVariable("pg_net.database_name",


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?

Changing `pg_net.ttl` and `pg_net.batch_size` requires `ALTER SYSTEM` (which is SU-only) and a config reload.

## What is the new behavior?

`pg_net.ttl` and `pg_net.batch_size` can be changed with `ALTER ROLE ... SET ...` + a config reload.