### PR TITLE
chore: bring back load testing with nixops

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -74,6 +74,48 @@ $ nix-shell
 $ sudo with-gdb -p 1145879
 ```
 
+## Load Testing
+
+This will deploy a client and server on t3a.nano. You must have `default` setup in `.aws/credentials`.
+
+```bash
+cd nix
+
+nixops create -d pg_net
+
+# will take a while
+nixops deploy -k -d pg_net --allow-reboot --confirm
+```
+
+Then you can connect on the client instance and do requests to the server instance through `pg_net`.
+
+```bash
+cd nix
+
+nixops ssh -d pg_net client
+
+psql -U postgres
+
+create extension pg_net;
+
+select net.http_get('http://server');
+# this the default welcome page of nginx on the server instance
+# "server" is already included to /etc/hosts, so `curl http://server` will give the same result
+
+# do some load testing
+select net.http_get('http://server') from generate_series(1,1000);
+# run `top` on another shell(another `nixops ssh -d pg_net client`) to check the worker behavior
+```
+
+To destroy the instances:
+
+```bash
+cd nix
+
+nixops destroy -d pg_net --confirm
+nixops delete -d pg_net
+```
+
 ## Documentation
 
 All public API must be documented. Building documentation requires python 3.6+

--- a/nix/nginxCustom.nix
+++ b/nix/nginxCustom.nix
@@ -7,14 +7,15 @@ let
     src = fetchFromGitHub {
       owner  = "steve-chavez";
       repo   = name;
-      rev    = "5eae52b15b0785765c5de17ede774f04cd60729d";
-      sha256 = "sha256-oDvEZ2OVnM8lePYBUkQa294FLcLnxYMpE40S4XmqdBY=";
+      rev    = "668126a815daaf741433409a5afff5932e2fb2af";
+      sha256 = "sha256-tl7NoPlQCN9DDYQLRrHA3bP5csqbXUW9ozLKPbH2dfI=";
     };
     meta = with lib; {
       license = with licenses; [ mit ];
     };
   };
   customNginx = nginx.override {
+    configureFlags = ["--with-cc='c99'"];
     modules = [
       nginxModules.echo
       ngx_pathological
@@ -32,4 +33,7 @@ let
     "$@"
   '';
 in
-writeShellScriptBin "net-with-nginx" script
+{
+  customNginx = customNginx;
+  nginxScript = writeShellScriptBin "net-with-nginx" script;
+}

--- a/nix/nixops.nix
+++ b/nix/nixops.nix
@@ -1,0 +1,160 @@
+let
+  region = "us-east-2";
+  accessKeyId = "default";
+in {
+  network.storage.legacy = {
+    databasefile = ".deployments.nixops";
+  };
+
+  network.description = "pg_net load testing setup";
+
+  resources = {
+    ec2KeyPairs.netKP = { inherit region accessKeyId; };
+    vpc.netVpc = {
+      inherit region accessKeyId;
+      enableDnsSupport = true;
+      enableDnsHostnames = true;
+      cidrBlock = "10.0.0.0/24";
+    };
+    vpcSubnets.netSubnet = {resources, ...}: {
+      inherit region accessKeyId;
+      zone = "${region}a";
+      vpcId = resources.vpc.netVpc;
+      cidrBlock = "10.0.0.0/24";
+      mapPublicIpOnLaunch = true;
+    };
+    vpcInternetGateways.netIG = { resources, ... }: {
+      inherit region accessKeyId;
+      vpcId = resources.vpc.netVpc;
+    };
+    vpcRouteTables.netRT = { resources, ... }: {
+      inherit region accessKeyId;
+      vpcId = resources.vpc.netVpc;
+    };
+    vpcRoutes.netIGRoute = { resources, ... }: {
+      inherit region accessKeyId;
+      routeTableId = resources.vpcRouteTables.netRT;
+      destinationCidrBlock = "0.0.0.0/0";
+      gatewayId = resources.vpcInternetGateways.netIG;
+    };
+    vpcRouteTableAssociations.netTblAssoc = { resources, ... }: {
+      inherit region accessKeyId;
+      subnetId = resources.vpcSubnets.netSubnet;
+      routeTableId = resources.vpcRouteTables.netRT;
+    };
+    ec2SecurityGroups.netSecGroup = {resources, ...}: {
+      inherit region accessKeyId;
+      vpcId = resources.vpc.netVpc;
+      rules = [
+        { fromPort = 80;  toPort = 80;    sourceIp = "0.0.0.0/0"; }
+        { fromPort = 22;  toPort = 22;    sourceIp = "0.0.0.0/0"; }
+        { fromPort = 0;   toPort = 65535; sourceIp = resources.vpcSubnets.netSubnet.cidrBlock; }
+      ];
+    };
+  };
+
+  server = { config, pkgs, resources, ... }: {
+    deployment = {
+      targetEnv = "ec2";
+      ec2 = {
+        inherit region accessKeyId;
+        instanceType             = "t3a.micro";
+        associatePublicIpAddress = true;
+        keyPair                  = resources.ec2KeyPairs.netKP;
+        subnetId                 = resources.vpcSubnets.netSubnet;
+        securityGroupIds         = [resources.ec2SecurityGroups.netSecGroup.name];
+      };
+    };
+
+    services.nginx = {
+      enable = true;
+      package = (pkgs.callPackage ./nginxCustom.nix {}).customNginx;
+      config = ''
+        worker_processes auto;
+        events {
+          worker_connections 1024;
+        }
+        http {
+          server {
+            listen 0.0.0.0:80 ;
+            listen [::]:80 ;
+            server_name localhost;
+            ${builtins.readFile nginx/conf/custom.conf}
+          }
+        }
+      '';
+    };
+    networking.firewall.allowedTCPPorts = [ 80 ];
+  };
+
+  client = { config, pkgs, nodes, resources, ... }: {
+    deployment = {
+      targetEnv = "ec2";
+      ec2 = {
+        inherit region accessKeyId;
+        instanceType             = "t3a.micro";
+        associatePublicIpAddress = true;
+        ebsInitialRootDiskSize   = 6;
+        keyPair                  = resources.ec2KeyPairs.netKP;
+        subnetId                 = resources.vpcSubnets.netSubnet;
+        securityGroupIds         = [resources.ec2SecurityGroups.netSecGroup.name];
+      };
+    };
+
+    services.postgresql = {
+      enable = true;
+      package = pkgs.postgresql_15.withPackages (p: [
+        (pkgs.callPackage ./pg_net.nix { postgresql = pkgs.postgresql_15;})
+      ]);
+      authentication = pkgs.lib.mkOverride 10 ''
+        local   all all trust
+      '';
+      settings = {
+        shared_preload_libraries = "pg_net";
+      };
+      initialScript = pkgs.writeText "init-sql-script" ''
+        create extension pg_net;
+
+        alter system set pg_net.batch_size to 32000;
+
+        select net.worker_restart();
+
+        create view pg_net_stats as
+        select
+          count(*) filter (where error_msg is null) as request_successes,
+          count(*) filter (where error_msg is not null) as request_failures,
+          (select error_msg from net._http_response where error_msg is not null order by id desc limit 1) as last_failure_error
+        from net._http_response;
+      '';
+    };
+
+    networking.hosts = {
+      "${nodes.server.config.networking.privateIPv4}" = [ "server" ];
+    };
+
+    environment.systemPackages = [
+      pkgs.vegeta
+      (
+        pkgs.writeShellScriptBin "vegeta-bench" ''
+          # rate=0 means maximum rate subject to max-workers
+          echo "GET http://server/pathological?status=200" | vegeta attack -rate=0 -duration=1s -max-workers=1 | tee results.bin | vegeta report
+        ''
+      )
+      (
+        pkgs.writeShellScriptBin "vegeta-bench-max-requests" ''
+          # rate=0 means maximum rate subject to max-workers
+          echo "GET http://server/pathological?status=200" | vegeta attack -rate=0 -duration=10s -max-workers=50 | tee results.bin | vegeta report
+        ''
+      )
+      (
+        pkgs.writeShellScriptBin "net-bench" ''
+          psql -U postgres -c "truncate net._http_response;"
+          psql -U postgres -c "select net.http_get('http://server/pathological?status=200') from generate_series(1, 400);" > /dev/null
+          sleep 2
+          psql -U postgres -c "select * from pg_net_stats;"
+        ''
+      )
+    ];
+  };
+
+}

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@ mkShell {
       ];
       pgWithExt = { pg }: pg.withPackages (p: [ (callPackage ./nix/pg_net.nix { postgresql = pg;}) ]);
       extAll = map (x: callPackage ./nix/pgScript.nix { postgresql = pgWithExt { pg = x;}; }) supportedPgVersions;
-      nginxScript = callPackage ./nix/nginxScript.nix {};
+      nginxCustom = callPackage ./nix/nginxCustom.nix {};
       gdbScript = callPackage ./nix/gdbScript.nix {};
       pythonDeps = with python3Packages; [
         pytest
@@ -28,8 +28,9 @@ mkShell {
       extAll
       pythonDeps
       format.do format.doCheck
-      nginxScript
+      nginxCustom.nginxScript
       gdbScript
+      (pkgs.nixops_unstable_minimal.withPlugins (ps: [ ps.nixops-aws ]))
     ];
   shellHook = ''
     export HISTFILE=.history


### PR DESCRIPTION
This is just for manual bench tests for now, to ensure a change doesn't cause a performance regression.

Adds the following nixops commands to reproduce some bench tests:

Note: All of the nixops command need to run on the nix directory (`cd nix`).

### max requests for the nginx server:

```
nixops ssh -d pg_net client vegeta-bench-max-requests
```

It's capable of handling ~12k req/s.

### reference bench test with the vegeta http client, only using one thread/worker:

```
nixops ssh -d pg_net client vegeta-bench-max-requests
```

Vegeta is able to do ~2.5K req/s.

### With a pg_net.batch_size=32000, this uses pg_net for the bench test:

```
nixops ssh -d pg_net client net-bench
```

pg_net reaches 400 req/s max before request errors are reported. Like `Couldn't resolve host name` or `Couldn't connect to server`.

These need further investigation, for now keeping the batch_size low is necessary for stability.