### PR TITLE
test: add cloud test for reproducing timeouts

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -72,27 +72,18 @@ $ sudo with-gdb -p 1145879
 
 ## Load Testing
 
-This will deploy a client and server on t3a.nano. You must have `default` setup in `.aws/credentials`.
+These are scripts that wrap NixOps to deploy an AWS cloud setup. You must have `default` setup in `.aws/credentials`.
 
 ```bash
-cd nix
-
-nixops create -d pg_net
-
-# will take a while
-nixops deploy -k -d pg_net --allow-reboot --confirm
+net-cloud-deploy
 ```
 
 Then you can connect on the client instance and do requests to the server instance through `pg_net`.
 
 ```bash
-cd nix
-
-nixops ssh -d pg_net client
+net-cloud-ssh
 
 psql -U postgres
-
-create extension pg_net;
 
 select net.http_get('http://server');
 # this the default welcome page of nginx on the server instance
@@ -103,13 +94,10 @@ select net.http_get('http://server') from generate_series(1,1000);
 # run `top` on another shell(another `nixops ssh -d pg_net client`) to check the worker behavior
 ```
 
-To destroy the instances:
+To destroy the cloud setup:
 
 ```bash
-cd nix
-
-nixops destroy -d pg_net --confirm
-nixops delete -d pg_net
+net-cloud-destroy
 ```
 
 ## Documentation

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,11 +25,7 @@ $ net-with-pg-13 python -m pytest -vv"
 You can turn on logging level to see curl traces with
 
 ```
-$ export LOGMIN=DEBUG1 # must be done outside nix-shell, then go in nix-shell as usual
-
-$ nix-shell
-
-$ net-with-pg-12 psql
+$ LOG_MIN_MESSAGES=debug2 net-with-pg-12 psql
 ```
 
 ```sql

--- a/nix/nginx/conf/custom.conf
+++ b/nix/nginx/conf/custom.conf
@@ -24,9 +24,10 @@ location /post {
   if ($request_method != 'POST'){
       return 405;
   }
-  if ($http_accept != "application/json") {
+  if ($http_content_type  != "application/json") {
       return 406;
   }
+  default_type application/json;
   echo_read_request_body;
   echo $request_body;
 }

--- a/nix/nginx/conf/nginx.conf
+++ b/nix/nginx/conf/nginx.conf
@@ -1,7 +1,11 @@
 daemon off;
 pid        ./nginx.pid;
 
-events {}
+worker_processes auto;
+
+events {
+  worker_connections 1024;
+}
 
 http {
 

--- a/nix/nixopsScripts.nix
+++ b/nix/nixopsScripts.nix
@@ -1,0 +1,59 @@
+{ nixops_unstable_minimal, writeShellScriptBin } :
+
+let
+  nixops = nixops_unstable_minimal.withPlugins (ps: [ ps.nixops-aws ]);
+  nixopsBin = "${nixops}/bin/nixops";
+  nixopsDeploy =
+    writeShellScriptBin "net-cloud-deploy"
+      ''
+        set -euo pipefail
+
+        cd nix
+
+        set +e && ${nixopsBin} info -d pg_net > /dev/null 2> /dev/null
+        info=$? && set -e
+
+        if test $info -eq 1
+        then
+          echo "Creating deployment..."
+          ${nixopsBin} create -d pg_net
+        fi
+
+        ${nixopsBin} deploy -k -d pg_net --allow-reboot --confirm
+      '';
+  nixopsSSH =
+    writeShellScriptBin ("net-cloud-ssh")
+      ''
+        set -euo pipefail
+
+        cd nix
+
+        ${nixopsBin} ssh -d pg_net client
+      '';
+  nixopsReproTimeouts =
+    writeShellScriptBin ("net-cloud-reproduce-timeouts")
+      ''
+        set -euo pipefail
+
+        cd nix
+
+        ${nixopsBin} ssh -d pg_net client psql-reproduce-timeouts
+      '';
+  nixopsDestroy =
+    writeShellScriptBin ("net-cloud-destroy")
+      ''
+        set -euo pipefail
+
+        cd nix
+
+        ${nixopsBin} destroy -d pg_net --confirm
+
+        ${nixopsBin} delete -d pg_net
+      '';
+in
+[
+  nixopsDeploy
+  nixopsSSH
+  nixopsReproTimeouts
+  nixopsDestroy
+]

--- a/nix/pgScript.nix
+++ b/nix/pgScript.nix
@@ -1,8 +1,6 @@
 { postgresql, writeShellScriptBin } :
 
 let
-  LOGMIN = builtins.getEnv "LOGMIN";
-  logMin = if builtins.stringLength LOGMIN == 0 then "INFO" else LOGMIN;
   ver = builtins.head (builtins.splitVersion postgresql.version);
   script = ''
     set -euo pipefail
@@ -20,7 +18,7 @@ let
 
     PGTZ=UTC initdb --no-locale --encoding=UTF8 --nosync -U "$PGUSER"
 
-    options="-F -c listen_addresses=\"\" -c log_min_messages=${logMin} -k $PGDATA"
+    options="-F -c listen_addresses=\"\" -c log_min_messages=\"''${LOG_MIN_MESSAGES:-INFO}\" -k $PGDATA"
 
     ext_options="-c shared_preload_libraries=\"pg_net\""
 

--- a/shell.nix
+++ b/shell.nix
@@ -17,6 +17,7 @@ mkShell {
       extAll = map (x: callPackage ./nix/pgScript.nix { postgresql = pgWithExt { pg = x;}; }) supportedPgVersions;
       nginxCustom = callPackage ./nix/nginxCustom.nix {};
       gdbScript = callPackage ./nix/gdbScript.nix {};
+      nixopsScripts = callPackage ./nix/nixopsScripts.nix {};
       pythonDeps = with python3Packages; [
         pytest
         psycopg2
@@ -30,8 +31,7 @@ mkShell {
       format.do format.doCheck
       nginxCustom.nginxScript
       gdbScript
-      (pkgs.nixops_unstable_minimal.withPlugins (ps: [ ps.nixops-aws ]))
-    ];
+    ] ++ nixopsScripts;
   shellHook = ''
     export HISTFILE=.history
   '';

--- a/src/worker.c
+++ b/src/worker.c
@@ -193,7 +193,7 @@ static void init_curl_handle(CURLM *curl_mhandle, CurlData *cdata, char *url, ch
   CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_TIMEOUT_MS, timeout_milliseconds);
   CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_PRIVATE, cdata);
   CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_FOLLOWLOCATION, true);
-  if (log_min_messages <= DEBUG1)
+  if (log_min_messages <= DEBUG2)
     CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_VERBOSE, 1L);
 #if LIBCURL_VERSION_NUM >= 0x075500 /* libcurl 7.85.0 */
   CURL_EZ_SETOPT(curl_ez_handle, CURLOPT_PROTOCOLS_STR, "http,https");


### PR DESCRIPTION
This is a test that can only be ran manually since it requires AWS. It adds NixOps wrapper scripts to reproduce https://github.com/supabase/pg_net/issues/86.

The steps are:

```
$ net-cloud-deploy
$ net-cloud-reproduce-timeouts
NOTICE:  Waiting until 10000 requests complete
NOTICE:  Stats: {"request_successes":8882,"request_failures":1118,"last_failure_error":"Timeout was reached"}
NOTICE:  Time taken: 00:01:44.341157
```

Then destroy the cloud setup with `net-cloud-destroy`

Note that it takes 01:44, it should be ~50 seconds to finish processing all the 10K requests, considering batch_size=200 (the default).