### PR TITLE
refactor: use pg WaitEvent API instead of epoll

### DIFF
--- a/src/core.h
+++ b/src/core.h
@@ -1,13 +1,9 @@
 #ifndef CORE_H
 #define CORE_H
 
-typedef struct itimerspec itimerspec;
-typedef struct epoll_event epoll_event;
-
 typedef struct {
-  int epfd;
-  int timerfd;
   CURLM *curl_mhandle;
+  WaitEventSet *event_set;
 } LoopState;
 
 void delete_expired_responses(char *ttl, int batch_size);


### PR DESCRIPTION
This allows compiling on other platforms such as MacOS. (problem previously mentioned on https://github.com/supabase/pg_net/pull/139#issuecomment-2387312836)

It mostly works at this stage but with some limitations:

- [ ] Doing 10K requests fail with "Bad file descriptor"
  + I believe this is because we're not deleting file descriptors since the WaitEvent API doesn't provide EPOLL_CTL_DEL. It only provides EPOLL_CTL_ADD/MOD
- [ ] timerfd is still Linux specific and pg provides no abstraction over it.