### PR TITLE
feat: set appname for pg_stat_activity entry

### DIFF
--- a/src/event.c
+++ b/src/event.c
@@ -14,7 +14,7 @@ typedef struct epoll_event epoll_event;
 typedef struct itimerspec itimerspec;
 
 int inline wait_event(int fd, event *events, size_t maxevents, int wait_milliseconds){
-  return epoll_wait(fd, events, maxevents, /*timeout=*/1000);
+  return epoll_wait(fd, events, maxevents, /*timeout=*/wait_milliseconds);
 }
 
 int inline event_monitor(){

--- a/src/worker.c
+++ b/src/worker.c
@@ -102,6 +102,7 @@ void pg_net_worker(Datum main_arg) {
   BackgroundWorkerUnblockSignals();
 
   BackgroundWorkerInitializeConnection(guc_database_name, guc_username, 0);
+  pgstat_report_appname("pg_net " EXTVERSION); // set appname for pg_stat_activity
 
   elog(INFO, "pg_net_worker started with a config of: pg_net.ttl=%s, pg_net.batch_size=%d, pg_net.username=%s, pg_net.database_name=%s", guc_ttl, guc_batch_size, guc_username, guc_database_name);
 

--- a/test/test_user_db.py
+++ b/test/test_user_db.py
@@ -32,3 +32,17 @@ def test_net_with_different_username_dbname(sess):
 
     # bg worker restarts after 1 second
     time.sleep(1.1)
+
+
+def test_net_appname(sess):
+    """Check that pg_stat_activity has appname set"""
+
+    ## can use the net.worker_restart function
+    (count,) = sess.execute(
+        text(
+            """
+        select count(1) from pg_stat_activity where application_name like '%pg_net%';
+    """
+        )
+    ).fetchone()
+    assert count == 1


### PR DESCRIPTION
This is so `select * from pg_stat_activity where application_name like '%pg_net%';` can work as usual.