### PR TITLE
repro memory leak under pg_stat_monitor

### DIFF
--- a/nix/pg_stat_monitor.nix
+++ b/nix/pg_stat_monitor.nix
@@ -1,0 +1,32 @@
+{ lib, stdenv, fetchFromGitHub, postgresql }:
+
+stdenv.mkDerivation rec {
+  pname = "pg_stat_monitor";
+  version = "2.1.1";
+
+  buildInputs = [ postgresql ];
+
+  src = fetchFromGitHub {
+    owner = "percona";
+    repo = pname;
+    rev = "refs/tags/${version}";
+    hash = "sha256-c50l6XpkF5lp8TQd9TFqnms3nc8KAAa+dV/wVjw3Zao=";
+  };
+
+  makeFlags = [ "USE_PGXS=1" ];
+
+  installPhase = ''
+    install -D -t $out *${postgresql.dlSuffix}
+    install -D -t $out *.sql
+    install -D -t $out *.control
+  '';
+
+  meta = with lib; {
+    description = "Query Performance Monitoring Tool for PostgreSQL";
+    homepage = "https://github.com/percona/${pname}";
+    maintainers = with maintainers; [ samrose ];
+    platforms = postgresql.meta.platforms;
+    license = licenses.postgresql;
+    broken = lib.versionOlder postgresql.version "15";
+  };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -10,6 +10,9 @@ mkShell {
       nixopsScripts = callPackage ./nix/nixopsScripts.nix {};
       xpg = callPackage ./nix/xpg.nix {inherit fetchFromGitHub;};
       loadtest = callPackage ./nix/loadtest.nix {};
+      pg_stat_monitor15 = callPackage ./nix/pg_stat_monitor.nix {
+        postgresql = xpg.postgresql_15;
+      };
       pythonDeps = with python3Packages; [
         pytest
         psycopg2
@@ -17,7 +20,9 @@ mkShell {
       ];
     in
     [
-      xpg.xpg
+      (xpg.xpgWithExtensions {
+        exts15 = [ pg_stat_monitor15 ];
+      })
       pythonDeps
       nginxCustom.nginxScript
       curl

--- a/test/init.conf
+++ b/test/init.conf
@@ -1,2 +1,2 @@
-shared_preload_libraries='pg_net, pg_stat_statements'
+shared_preload_libraries='pg_net, pg_stat_statements, pg_stat_monitor'
 log_min_messages=DEBUG1


### PR DESCRIPTION
## Problem

When adding `pg_stat_monitor` like:

```
shared_preload_libraries='pg_net, pg_stat_monitor'
```

Memory usage keeps increasing for the pg_net background worker.

To prove this execute in one terminal:

```bash
xpg -v 15 psql
```

And this in another:

```bash
watch -n 1 'ps -p $(cat build-15/bgworker.pid) -o %mem,rss,vsz,comm'

%MEM   RSS    VSZ COMMAND
 0.1 19164 722508 postgres
```

The RSS should be seen as always growing, which proves the memory leak.

## Root cause

pg_stat_monitor statistics are split into configurable time intervals ([buckets](https://docs.percona.com/pg-stat-monitor/user_guide.html#time-buckets)). As one bucket fills or a time interval passes, pg_stat_monitor creates a new one, keeping historical data in distinct buckets.

pg_net queries its internal tables each second.

This means that the "memory leak" is actually expected behavior by pg_stat_monitor.

We need to fix this in pg_net itself, by doing https://github.com/supabase/pg_net/issues/164.