### PR TITLE
refactor: remove strict and parallel safe attrs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,6 @@ __pycache__/
 .deployment.nixops*
 valgrindlog
 nix/nginx/logs/nginx.pid
-pg_net--*.sql
 .history
 *.o
 *.bc

--- a/sql/pg_net--0.15.0--new.sql
+++ b/sql/pg_net--0.15.0--new.sql
@@ -1,0 +1,17 @@
+alter function net._await_response(bigint) parallel unsafe called on null input;
+
+alter function net._urlencode_string(varchar) called on null input;
+
+alter function net._encode_url_with_params_array(text, text[]) called on null input;
+
+alter function net._await_response(bigint) parallel unsafe called on null input;
+
+alter function net.http_get(text, jsonb , jsonb , int) parallel unsafe called on null input;
+
+alter function net.http_post(text, jsonb , jsonb , jsonb, int) parallel unsafe;
+
+alter function net.http_delete(text, jsonb , jsonb, int, jsonb) parallel unsafe;
+
+alter function net._http_collect_response(bigint, bool) parallel unsafe called on null input;
+
+alter function net.http_collect_response(bigint, bool) parallel unsafe called on null input;

--- a/sql/pg_net.sql
+++ b/sql/pg_net.sql
@@ -51,9 +51,6 @@ create or replace function net._await_response(
     request_id bigint
 )
     returns bool
-    volatile
-    parallel safe
-    strict
     language plpgsql
 as $$
 declare
@@ -81,17 +78,14 @@ $$;
 create or replace function net._urlencode_string(string varchar)
     -- url encoded string
     returns text
-
     language 'c'
     immutable
-    strict
 as 'pg_net';
 
 -- API: Private
 create or replace function net._encode_url_with_params_array(url text, params_array text[])
     -- url encoded string
     returns text
-    strict
     language 'c'
     immutable
 as 'pg_net';
@@ -115,9 +109,6 @@ create or replace function net.http_get(
 )
     -- request_id reference
     returns bigint
-    strict
-    volatile
-    parallel safe
     language plpgsql
 as $$
 declare
@@ -159,8 +150,6 @@ create or replace function net.http_post(
 )
     -- request_id reference
     returns bigint
-    volatile
-    parallel safe
     language plpgsql
 as $$
 declare
@@ -229,8 +218,6 @@ create or replace function net.http_delete(
 )
     -- request_id reference
     returns bigint
-    volatile
-    parallel safe
     language plpgsql
 as $$
 declare
@@ -289,9 +276,6 @@ create or replace function net._http_collect_response(
 )
     -- http response composite wrapped in a result type
     returns net.http_response_result
-    strict
-    volatile
-    parallel safe
     language plpgsql
 as $$
 declare
@@ -343,9 +327,6 @@ create or replace function net.http_collect_response(
 )
     -- http response composite wrapped in a result type
     returns net.http_response_result
-    strict
-    volatile
-    parallel safe
     language plpgsql
 as $$
 begin

--- a/src/util.c
+++ b/src/util.c
@@ -6,6 +6,9 @@ PG_FUNCTION_INFO_V1(_urlencode_string);
 PG_FUNCTION_INFO_V1(_encode_url_with_params_array);
 
 Datum _urlencode_string(PG_FUNCTION_ARGS) {
+    if(PG_GETARG_POINTER(0) == NULL)
+      PG_RETURN_NULL();
+
     char *str = text_to_cstring(PG_GETARG_TEXT_P(0));
     char *urlencoded_str = NULL;
 
@@ -17,11 +20,12 @@ Datum _urlencode_string(PG_FUNCTION_ARGS) {
 }
 
 Datum _encode_url_with_params_array(PG_FUNCTION_ARGS) {
-    CURLU *h = curl_url();
-    CURLUcode rc;
+    if(PG_GETARG_POINTER(0) == NULL || PG_GETARG_POINTER(1) == NULL)
+      PG_RETURN_NULL();
 
     char *url = text_to_cstring(PG_GETARG_TEXT_P(0));
     ArrayType *params = PG_GETARG_ARRAYTYPE_P(1);
+
     char *full_url = NULL;
 
     ArrayIterator iterator;
@@ -29,7 +33,8 @@ Datum _encode_url_with_params_array(PG_FUNCTION_ARGS) {
     bool isnull;
     char *param;
 
-    rc = curl_url_set(h, CURLUPART_URL, url, 0);
+    CURLU *h = curl_url();
+    CURLUcode rc = curl_url_set(h, CURLUPART_URL, url, 0);
     if (rc != CURLUE_OK) {
         // TODO: Use curl_url_strerror once released.
         elog(ERROR, "%s", curl_easy_strerror((CURLcode)rc));

--- a/test/test_http_errors.py
+++ b/test/test_http_errors.py
@@ -29,6 +29,50 @@ def test_bad_post(sess):
     assert 'null value in column "url"' in str(execinfo)
 
 
+def test_bad_get(sess):
+    """net.http_get with an empty url + body returns an error"""
+
+    with pytest.raises(Exception) as execinfo:
+        res = sess.execute(text(
+            """
+            select net.http_get(null);
+        """
+        ))
+    assert 'null value in column "url"' in str(execinfo)
+
+
+def test_bad_delete(sess):
+    """net.http_delete with an empty url + body returns an error"""
+
+    with pytest.raises(Exception) as execinfo:
+        res = sess.execute(text(
+            """
+            select net.http_delete(null);
+        """
+        ))
+    assert 'null value in column "url"' in str(execinfo)
+
+
+def test_bad_utils(sess):
+    """util functions of pg_net return null"""
+
+    res = sess.execute(text(
+        """
+        select net._encode_url_with_params_array(null, null);
+    """
+    )).scalar_one()
+
+    assert res is None
+
+    res = sess.execute(text(
+        """
+        select net._urlencode_string(null);
+    """
+    )).scalar_one()
+
+    assert res is None
+
+
 def test_it_keeps_working_after_many_connection_refused(sess):
     """the worker doesn't crash on many failed responses with connection refused"""
 
@@ -39,7 +83,7 @@ def test_it_keeps_working_after_many_connection_refused(sess):
     ))
     sess.commit()
 
-    time.sleep(1.5)
+    time.sleep(2)
 
     (error_msg,count) = sess.execute(text(
     """


### PR DESCRIPTION
Closes https://github.com/supabase/pg_net/issues/172.

A test is added on a previous commit to ensure the behavior is maintained.

Also, remove PARALLEL SAFE since these functions are really PARALLEL UNSAFE, as mentioned on the docs:

> Functions and aggregates must be marked PARALLEL UNSAFE if they write to the database
> https://www.postgresql.org/docs/current/parallel-safety.html