### PR TITLE
feat: add `net.wait_until_running` sql function 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ nginx.pid
 tags
 net_worker.pid
 psrecord.*
+pg_net--*.sql
+!pg_net--*--*.sql

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ PG_CFLAGS += --coverage
 endif
 
 EXTENSION = pg_net
-EXTVERSION = 0.16.0
+EXTVERSION = 0.17.0
 
 DATA = $(wildcard sql/*--*.sql)
 

--- a/sql/pg_net--0.16.0--0.17.0.sql
+++ b/sql/pg_net--0.16.0--0.17.0.sql
@@ -1,0 +1,5 @@
+create or replace function net.wait_until_running()
+  returns void
+  language 'c'
+as 'pg_net';
+comment on function net.wait_until_running() is 'waits until the worker is running';

--- a/sql/pg_net.sql
+++ b/sql/pg_net.sql
@@ -95,6 +95,12 @@ create or replace function net.worker_restart()
   language 'c'
 as 'pg_net';
 
+create or replace function net.wait_until_running()
+  returns void
+  language 'c'
+as 'pg_net';
+comment on function net.wait_until_running() is 'waits until the worker is running';
+
 -- Interface to make an async request
 -- API: Public
 create or replace function net.http_get(

--- a/src/pg_prelude.h
+++ b/src/pg_prelude.h
@@ -6,6 +6,7 @@
 #include <postgres.h>
 #include <postmaster/bgworker.h>
 #include <pgstat.h>
+#include <storage/condition_variable.h>
 #include <storage/ipc.h>
 #include <storage/latch.h>
 #include <storage/proc.h>

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -10,9 +10,7 @@ def test_http_requests_deleted_after_ttl(sess):
     sess.execute(text("COMMIT"))
     sess.execute(text("alter system set pg_net.ttl to '4 seconds'"))
     sess.execute(text("select net.worker_restart()"))
-
-    # bg worker restarts after 1 second
-    time.sleep(1)
+    sess.execute(text("select net.wait_until_running()"))
 
     # Create a request
     (request_id,) = sess.execute(text(
@@ -55,6 +53,4 @@ def test_http_requests_deleted_after_ttl(sess):
     sess.execute(text("COMMIT"))
     sess.execute(text("alter system reset pg_net.ttl"))
     sess.execute(text("select net.worker_restart()"))
-
-    # wait until the worker has restarted to not affect other tests
-    time.sleep(1)
+    sess.execute(text("select net.wait_until_running()"))

--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -108,6 +108,7 @@ def test_net_on_new_role(sess):
     assert response[0] == True
 
     sess.execute(text("""
+        select net.wait_until_running();
         set local role postgres;
         drop role another;
     """))

--- a/test/test_user_db.py
+++ b/test/test_user_db.py
@@ -11,11 +11,8 @@ def test_net_with_different_username_dbname(sess):
     sess.execute(text("alter system set pg_net.username to 'pre_existing'"))
     sess.execute(text("alter system set pg_net.database_name to 'pre_existing'"))
     sess.execute(text("select net.worker_restart()"))
+    sess.execute(text("select net.wait_until_running()"))
 
-    # bg worker restarts after 1 second
-    time.sleep(1.1)
-
-    ## can use the net.worker_restart function
     (username,datname) = sess.execute(
         text(
             """
@@ -30,15 +27,11 @@ def test_net_with_different_username_dbname(sess):
     sess.execute(text("alter system reset pg_net.username"))
     sess.execute(text("alter system reset pg_net.database_name"))
     sess.execute(text("select net.worker_restart()"))
-
-    # bg worker restarts after 1 second
-    time.sleep(1.1)
-
+    sess.execute(text("select net.wait_until_running()"))
 
 def test_net_appname(sess):
     """Check that pg_stat_activity has appname set"""
 
-    ## can use the net.worker_restart function
     (count,) = sess.execute(
         text(
             """

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -5,9 +5,8 @@ import time
 def test_success_when_worker_is_up(sess):
     """net.check_worker_is_up should not return anything when the worker is running"""
 
-    time.sleep(1) # wait if another test did a net.worker_restart()
-
     (result,) = sess.execute(text("""
+        select net.wait_until_running();
         select net.check_worker_is_up();
     """)).fetchone()
     assert result is not None


### PR DESCRIPTION
Required for solving https://github.com/supabase/pg_net/issues/164, otherwise tests would break.

Adds a `net.wait_until_running` SQL function that waits until the worker runs again after a `net.worker_restart`. This avoids having to do sleeps in tests to wait for the worker to be running again.

For this, we add some states for the background worker state machine. This to allow waiting until it reaches a RUNNING state on tests.