### PR TITLE
fix: incorrect GUC contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,14 @@ alter system set pg_net.ttl to '1 hour'
 alter system set pg_net.batch_size to 500;
 ```
 
-Then, reload the settings and restart the `pg_net` background worker with:
+Then, you can reload the settings with:
+
+```
+select pg_reload_conf();
+```
+
+If you change the `pg_net.database_name` and `pg_net.username` configs, you'll need to restart the worker for them to apply.
+We provide a function reloads the config with `pg_reload_conf` and restarts the worker in one go:
 
 ```
 select net.worker_restart();

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ select pg_reload_conf();
 ```
 
 If you change the `pg_net.database_name` and `pg_net.username` configs, you'll need to restart the worker for them to apply.
-We provide a function reloads the config with `pg_reload_conf` and restarts the worker in one go:
+We provide a function that reloads the config with `pg_reload_conf` and restarts the worker in one go:
 
 ```
 select net.worker_restart();

--- a/src/worker.c
+++ b/src/worker.c
@@ -289,7 +289,7 @@ void _PG_init(void) {
                  "should be a valid interval type",
                  &guc_ttl,
                  "6 hours",
-                 PGC_SUSET, 0,
+                 PGC_SIGHUP, 0,
                  NULL, NULL, NULL);
 
   DefineCustomIntVariable("pg_net.batch_size",
@@ -298,7 +298,7 @@ void _PG_init(void) {
                  &guc_batch_size,
                  200,
                  0, PG_INT16_MAX,
-                 PGC_SUSET, 0,
+                 PGC_SIGHUP, 0,
                  NULL, NULL, NULL);
 
   DefineCustomStringVariable("pg_net.database_name",
@@ -306,7 +306,7 @@ void _PG_init(void) {
                 NULL,
                 &guc_database_name,
                 "postgres",
-                PGC_SIGHUP, 0,
+                PGC_SU_BACKEND, 0,
                 NULL, NULL, NULL);
 
   DefineCustomStringVariable("pg_net.username",
@@ -314,6 +314,6 @@ void _PG_init(void) {
                 NULL,
                 &guc_username,
                 NULL,
-                PGC_SIGHUP, 0,
+                PGC_SU_BACKEND, 0,
                 NULL, NULL, NULL);
 }


### PR DESCRIPTION
PGC_SUSET was used for `pg_net.ttl/batch_size`, which was incorrect because those cannot be altered via `SET`, since the background worker runs outside of the client session.

Now an adequate PGC_SIGHUP is used for them.

PGC_SIGHUP was used for `pg_net.username/database_name`, which was incorrect since those can't be reloaded unless the worker restarts (BackgroundWorkerInitializeConnection can only be done at startup).

Now an adequate PGC_SU_BACKEND is used for them.

Also change the README.md to clarify the former require `pg_reload_conf` while the latter require a `net.worker_restart`.