### PR TITLE
test: remove "no transaction in progress" warnings 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,4 +62,4 @@ include $(PGXS)
 
 .PHONY: test
 test:
-	net-with-nginx python -m pytest -s --full-trace -vv
+	net-with-nginx python -m pytest -s -vv

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -15,6 +15,9 @@ def sess(engine):
 
     session = Session(engine)
 
+    # no autocommit
+    session.connection().connection.set_isolation_level(0)
+
     # Reset sequences and tables between tests
     session.execute(text(
         """

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -6,8 +6,6 @@ from sqlalchemy import text
 def test_http_requests_deleted_after_ttl(sess):
     """Check that http requests are deleted within a few seconds of their ttl"""
 
-    # commit to avoid "cannot run inside a transaction block" error, see https://stackoverflow.com/a/75757326/4692662
-    sess.execute(text("COMMIT"))
     sess.execute(text("alter system set pg_net.ttl to '4 seconds'"))
     sess.execute(text("select net.worker_restart()"))
     sess.execute(text("select net.wait_until_running()"))
@@ -49,7 +47,6 @@ def test_http_requests_deleted_after_ttl(sess):
     ).fetchone()
     assert count == 0
 
-    sess.execute(text("COMMIT"))
     sess.execute(text("alter system reset pg_net.ttl"))
     sess.execute(text("select net.worker_restart()"))
     sess.execute(text("select net.wait_until_running()"))

--- a/test/test_user_db.py
+++ b/test/test_user_db.py
@@ -6,8 +6,6 @@ from sqlalchemy import text
 def test_net_with_different_username_dbname(sess):
     """Check that a pre existing role can use the net schema"""
 
-    # commit to avoid "cannot run inside a transaction block" error, see https://stackoverflow.com/a/75757326/4692662
-    sess.execute(text("COMMIT"))
     sess.execute(text("alter system set pg_net.username to 'pre_existing'"))
     sess.execute(text("alter system set pg_net.database_name to 'pre_existing'"))
     sess.execute(text("select net.worker_restart()"))
@@ -23,7 +21,6 @@ def test_net_with_different_username_dbname(sess):
     assert username == 'pre_existing'
     assert datname == 'pre_existing'
 
-    sess.execute(text("COMMIT"))
     sess.execute(text("alter system reset pg_net.username"))
     sess.execute(text("alter system reset pg_net.database_name"))
     sess.execute(text("select net.worker_restart()"))


### PR DESCRIPTION
The pytest traces show:

WARNING:  there is no transaction in progress

Which is confusing, to clear this we just disable autocommit for the sql alchemy session.

Also remove some previous workarounds.