### PR TITLE
test: fix set local warnings

### DIFF
--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -5,7 +5,6 @@ def test_net_on_postgres_role(sess):
     """Check that the postgres role can use the net schema by default"""
 
     role = sess.execute(text("select current_user;")).fetchone()
-
     assert role[0] == "postgres"
 
     # Create a request
@@ -35,15 +34,20 @@ def test_net_on_postgres_role(sess):
 def test_net_on_pre_existing_role(sess):
     """Check that a pre existing role can use the net schema"""
 
+    role = sess.execute(text("select current_user;")).fetchone()
+    assert role[0] == "postgres"
+
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id, current_user) = sess.execute(text(
         """
         set local role to pre_existing;
         select net.http_get(
             'http://localhost:8080/anything'
-        );
+        ), current_user;
     """
     )).fetchone()
+    assert request_id == 1
+    assert current_user == 'pre_existing'
 
     # Commit so background worker can start
     sess.commit()
@@ -53,33 +57,35 @@ def test_net_on_pre_existing_role(sess):
         text(
             """
         set local role to pre_existing;
-        select * from net._http_collect_response(:request_id, async:=false);
+        select *, current_user from net._http_collect_response(:request_id, async:=false);
     """
         ),
         {"request_id": request_id},
     ).fetchone()
     assert response[0] == "SUCCESS"
-
-    sess.execute(text("""
-        set local role postgres;
-    """))
+    assert response[3] == 'pre_existing' # current-user
 
 def test_net_on_new_role(sess):
     """Check that a newly created role can use the net schema"""
+
+    role = sess.execute(text("select current_user;")).fetchone()
+    assert role[0] == "postgres"
 
     sess.execute(text("""
         create role another;
     """))
 
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id, current_user) = sess.execute(text(
         """
         set local role to another;
         select net.http_get(
             'http://localhost:8080/anything'
-        );
+        ), current_user;
     """
     )).fetchone()
+    assert request_id == 1
+    assert current_user == 'another'
 
     # Commit so background worker can start
     sess.commit()
@@ -89,23 +95,25 @@ def test_net_on_new_role(sess):
         text(
             """
         set local role to another;
-        select * from net._http_collect_response(:request_id, async:=false);
+        select *, current_user from net._http_collect_response(:request_id, async:=false);
     """
         ),
         {"request_id": request_id},
     ).fetchone()
     assert response[0] == "SUCCESS"
+    assert response[3] == 'another' # current-user
 
     ## can use the net.worker_restart function
-    response = sess.execute(
+    (res, current_user) = sess.execute(
         text(
             """
         set local role to another;
-        select net.worker_restart();
+        select net.worker_restart(), current_user;
     """
         )
     ).fetchone()
-    assert response[0] == True
+    assert res == True
+    assert current_user == 'another'
 
     sess.execute(text("""
         select net.wait_until_running();


### PR DESCRIPTION
This shows on pytest:

WARNING:  SET LOCAL can only be used in transaction blocks

Fix that by removing an unnecessary set local postgres. Plus ensure the tests are executed with the roles set with `set local role X`.