### PR TITLE
fix: locking the tables for too much time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 EXTENSION = pg_net
-EXTVERSION = 0.19.1
+EXTVERSION = 0.19.2
 
 DATA = $(wildcard sql/*--*.sql)
 

--- a/sql/pg_net--0.19.1--0.19.2.sql
+++ b/sql/pg_net--0.19.1--0.19.2.sql
@@ -1,0 +1,1 @@
+-- no SQL changes in 0.19.2

--- a/src/core.c
+++ b/src/core.c
@@ -137,9 +137,6 @@ void set_curl_mhandle(WorkerState *wstate){
 }
 
 uint64 delete_expired_responses(char *ttl, int batch_size){
-  SetCurrentStatementStartTimestamp();
-  StartTransactionCommand();
-  PushActiveSnapshot(GetTransactionSnapshot());
   SPI_connect();
 
   int ret_code = SPI_execute_with_args("\
@@ -168,8 +165,6 @@ uint64 delete_expired_responses(char *ttl, int batch_size){
   }
 
   SPI_finish();
-  PopActiveSnapshot();
-  CommitTransactionCommand();
 
   return affected_rows;
 }

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -91,6 +91,8 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
     sess.execute(text("select net.wake()"))
     sess.commit() # commit so worker  wakes
 
+    time.sleep(0.1)
+
     (count,) = sess.execute(
         text(
             """


### PR DESCRIPTION
If the worker process the queue for a long time, it will preventing operations like TRUNCATE or VACUUM FULL from completing.

This is because it acquires an AccessShareLock on the extension tables and only releases it once it goes to sleep.

Now we use `ConditionalLockRelationOid` and unlock the tables at the end of each transaction, allowing VACUUM FULL or TRUNCATE to finish fast.