### PR TITLE
fix: remove unnecessary not null from queue table

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 EXTENSION = pg_net
-EXTVERSION = 0.19.2
+EXTVERSION = 0.19.3
 
 DATA = $(wildcard sql/*--*.sql)
 

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ The extension introduces a new `net` schema, which contains two unlogged tables,
             id bigint NOT NULL DEFAULT nextval('net.http_request_queue_id_seq'::regclass),
             method text NOT NULL,
             url text NOT NULL,
-            headers jsonb NOT NULL,
-            body bytea NULL,
+            headers jsonb,
+            body bytea,
             timeout_milliseconds integer NOT NULL
         )
     ```

--- a/sql/pg_net--0.19.2--0.19.3.sql
+++ b/sql/pg_net--0.19.2--0.19.3.sql
@@ -1,0 +1,2 @@
+ALTER TABLE net.http_request_queue
+ALTER COLUMN headers DROP NOT NULL;

--- a/sql/pg_net.sql
+++ b/sql/pg_net.sql
@@ -13,7 +13,7 @@ create unlogged table net.http_request_queue(
     id bigserial,
     method net.http_method not null,
     url text not null,
-    headers jsonb not null,
+    headers jsonb,
     body bytea,
     timeout_milliseconds int not null
 );

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -174,3 +174,27 @@ def test_http_get_ipv6(sess):
 
     assert response is not None
     assert "Hello ipv6 only" in response[2]
+
+
+def test_http_get_null_headers(sess):
+    """net.http_get can have null headers"""
+
+    (request_id,) = sess.execute(text(
+        """
+        select net.http_get('http://localhost:8080', null::jsonb, null::jsonb, 100);
+    """
+    )).fetchone()
+
+    sess.commit()
+
+    response = sess.execute(
+        text(
+            """
+        select * from net._http_collect_response(:request_id, async:=false);
+    """
+        ),
+        {"request_id": request_id},
+    ).fetchone()
+
+    assert response is not None
+    assert "Hello world" in response[2]


### PR DESCRIPTION
Allows doing:

```sql
select net.http_get('http://localhost:8080', null::jsonb, null::jsonb, 100);
```