### PR TITLE
fix: incorrect shared memory setup 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 EXTENSION = pg_net
-EXTVERSION = 0.19.4
+EXTVERSION = 0.19.5
 
 DATA = $(wildcard sql/*--*.sql)
 

--- a/sql/pg_net--0.19.4--0.19.5.sql
+++ b/sql/pg_net--0.19.4--0.19.5.sql
@@ -1,0 +1,1 @@
+-- no SQL changes 0.19.5

--- a/src/pg_prelude.h
+++ b/src/pg_prelude.h
@@ -47,6 +47,8 @@
 
 #pragma GCC diagnostic pop
 
+#define PG15_GTE (PG_VERSION_NUM >= 150000)
+
 const char *xact_event_name(XactEvent event);
 #endif /* PG_PRELUDE_H */
 


### PR DESCRIPTION
Before the shared memory wasn't guarded with lwlocks plus there was no call to RequestAddinShmemSpace to estimate used memory (the latter only available on pg >= 15).

Closes https://github.com/supabase/pg_net/issues/220