### PR TITLE
chore: automatic cache import through flakes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,10 +13,8 @@ pg_net is OSS. PR and issues are welcome.
 For testing locally, execute:
 
 ```bash
-$ cachix use nxpg
-
-# might take a while in downloading all the dependencies
-$ nix-shell
+# This will download all the dependencies from the cache (when prompted for trusting the nxpg cache answer yes)
+$ nix develop
 
 # test on latest pg
 $ xpg test

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,63 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1762943920,
+        "narHash": "sha256-ITeH8GBpQTw9457ICZBddQEBjlXMmilML067q0e6vqY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "91c9a64ce2a84e648d0cf9671274bb9c2fb9ba60",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "91c9a64ce2a84e648d0cf9671274bb9c2fb9ba60",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1764521362,
+        "narHash": "sha256-M101xMtWdF1eSD0xhiR8nG8CXRlHmv6V+VoY65Smwf4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "871b9fd269ff6246794583ce4ee1031e1da71895",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "xpg": "xpg"
+      }
+    },
+    "xpg": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1778705163,
+        "narHash": "sha256-fCZFKnoE5zYoEMSEDLYZ87RELO8PYcVjATmnQZhRtAQ=",
+        "owner": "steve-chavez",
+        "repo": "xpg",
+        "rev": "c92037ecab9b368aa233c908d4d978c465bb82de",
+        "type": "github"
+      },
+      "original": {
+        "owner": "steve-chavez",
+        "ref": "v2.1.0",
+        "repo": "xpg",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,43 @@
+{
+  description = "Development shell for pg_net";
+
+  nixConfig = {
+    extra-substituters = [
+      "https://nxpg.cachix.org"
+    ];
+    extra-trusted-public-keys = [
+      "nxpg.cachix.org-1:6HKVOmmG/ptPEogBAJ+zR6kRji5F4uHTNx7EGt7WBh0="
+    ];
+  };
+
+  inputs = {
+    # 2025-11-13
+    nixpkgs.url = "github:NixOS/nixpkgs/91c9a64ce2a84e648d0cf9671274bb9c2fb9ba60";
+    xpg = {
+      url = "github:steve-chavez/xpg/v2.1.0";
+    };
+  };
+
+  outputs = { self, nixpkgs, xpg }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems (system: f system);
+    in
+    {
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          xpgPkgs = xpg.packages.${system};
+        in
+        {
+          default = import ./shell.nix {
+            inherit pkgs xpgPkgs;
+          };
+        });
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,34 +1,45 @@
-with import (builtins.fetchTarball {
-  name = "2025-11-13";
-  url = "https://github.com/NixOS/nixpkgs/archive/91c9a64ce2a84e648d0cf9671274bb9c2fb9ba60.tar.gz";
-  sha256 = "sha256:19myp93spfsf5x62k6ncan7020bmbn80kj4ywcykqhb9c3q8fdr1";
-}) {};
-mkShell {
+let
+  flakeLock = builtins.fromJSON (builtins.readFile ./flake.lock);
+  nixpkgsLock = flakeLock.nodes.nixpkgs.locked;
+  xpgLock = flakeLock.nodes.xpg.locked;
+in
+{ pkgs ?
+  import (builtins.fetchTarball {
+    name = nixpkgsLock.rev;
+    url = "https://github.com/${nixpkgsLock.owner}/${nixpkgsLock.repo}/archive/${nixpkgsLock.rev}.tar.gz";
+    sha256 = nixpkgsLock.narHash;
+  }) { }
+, xpgPkgs ?
+  import (pkgs.fetchFromGitHub {
+    inherit (xpgLock) owner repo rev;
+    sha256 = xpgLock.narHash;
+  })
+}:
+let
+  nginxCustom = pkgs.callPackage ./nix/nginxCustom.nix {};
+  loadtest = pkgs.callPackage ./nix/loadtest.nix {};
+  pythonDeps = with pkgs.python3Packages; [
+    pytest
+    psycopg2
+    sqlalchemy
+  ];
+  style =
+    pkgs.writeShellScriptBin "net-style" ''
+      ${pkgs.clang-tools}/bin/clang-format -i src/*
+    '';
+  styleCheck =
+    pkgs.writeShellScriptBin "net-style-check" ''
+      ${pkgs.clang-tools}/bin/clang-format -i src/*
+      ${pkgs.git}/bin/git diff-index --exit-code HEAD -- '*.c'
+    '';
+in
+pkgs.mkShell {
   buildInputs =
-    let
-      nginxCustom = callPackage ./nix/nginxCustom.nix {};
-      xpg = callPackage ./nix/xpg.nix {inherit fetchFromGitHub;};
-      loadtest = callPackage ./nix/loadtest.nix {};
-      pythonDeps = with python3Packages; [
-        pytest
-        psycopg2
-        sqlalchemy
-      ];
-      style =
-        writeShellScriptBin "net-style" ''
-          ${clang-tools}/bin/clang-format -i src/*
-        '';
-      styleCheck =
-        writeShellScriptBin "net-style-check" ''
-          ${clang-tools}/bin/clang-format -i src/*
-          ${git}/bin/git diff-index --exit-code HEAD -- '*.c'
-        '';
-    in
     [
-      xpg.xpg
+      xpgPkgs.xpg
       pythonDeps
       nginxCustom.nginxScript
-      curlWithGnuTls
+      pkgs.curlWithGnuTls
       loadtest
       style
       styleCheck


### PR DESCRIPTION
Now developers can use nix develop and it will automatically use the cache (answer yes when prompted to trust the nxpg cache).

```
$ nix develop
$ xpg -v 13 test
$ ...
```

`nix-shell` still works as usual.