### PR TITLE
fix: report worker activity to pg_stat_activity

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -265,6 +265,9 @@ void pg_net_worker(__attribute__((unused)) Datum main_arg) {
 
   publish_state(WS_RUNNING);
 
+  // Initial state: we go straight into the outer loop and wait for a wake.
+  pgstat_report_activity(STATE_IDLE, NULL);
+
   do {
 
     uint32 expected = 1;
@@ -273,6 +276,8 @@ void pg_net_worker(__attribute__((unused)) Datum main_arg) {
       wait_while_processing_interrupts(WORKER_WAIT_NO_TIMEOUT, &worker_should_restart);
       continue;
     }
+
+    pgstat_report_activity(STATE_RUNNING, NULL);
 
     uint64 requests_consumed = 0;
     uint64 expired_responses = 0;
@@ -396,6 +401,9 @@ void pg_net_worker(__attribute__((unused)) Datum main_arg) {
       wait_while_processing_interrupts(WORKER_WAIT_ONE_SECOND, &worker_should_restart);
 
     } while (!worker_should_restart && (requests_consumed > 0 || expired_responses > 0));
+
+    // Inner loop drained; back to waiting for the next wake.
+    pgstat_report_activity(STATE_IDLE, NULL);
 
   } while (!worker_should_restart);
 

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -588,3 +588,54 @@ def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_ses
     autocommit_sess.execute(text("alter system reset autovacuum_naptime;"))
     autocommit_sess.execute(text("select pg_reload_conf();"))
 
+
+def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
+    """the pg_net worker must call pgstat_report_activity() so its row in
+    pg_stat_activity has a valid state column.
+    """
+
+    autocommit_sess.execute(text("select net.wait_until_running();"))
+
+    # Wait for the worker to drain any leftover work from previous tests
+    # and settle into idle. Polling makes this robust regardless of what
+    # ran before.
+    deadline = time.time() + 5.0
+    state = None
+    while time.time() < deadline:
+        (state,) = autocommit_sess.execute(text(
+            "select state from pg_stat_activity where backend_type ilike '%pg_net%';"
+        )).fetchone()
+        if state == 'idle':
+            break
+        time.sleep(0.1)
+    assert state == 'idle', (
+        f"pg_net worker state expected 'idle' at rest, got {state!r}. "
+        "Without pgstat_report_activity(STATE_IDLE, ...) the state column "
+        "stays NULL."
+    )
+
+    # Fire a slow request so the worker stays active long enough to observe.
+    sess.execute(text("""
+        select net.http_get('http://localhost:8080/pathological?status=200&delay=2');
+    """))
+    sess.commit()
+
+    # Poll for 'active' for up to 5s. The slow request keeps the worker
+    # busy for ~2s, so we have a wide observation window.
+    deadline = time.time() + 5.0
+    saw_active = False
+    while time.time() < deadline:
+        (state,) = autocommit_sess.execute(text(
+            "select state from pg_stat_activity where backend_type ilike '%pg_net%';"
+        )).fetchone()
+        if state == 'active':
+            saw_active = True
+            break
+        time.sleep(0.1)
+
+    assert saw_active, (
+        "pg_net worker state was never observed as 'active' during a slow "
+        "request. Without pgstat_report_activity(STATE_RUNNING, ...) the "
+        "state column stays NULL."
+    )
+


### PR DESCRIPTION
## Problem

The pg_net background worker doesn't call `pgstat_report_activity()`, so its row in `pg_stat_activity` shows up with blank `state`, `query`, `query_start`, `xact_start`, and `state_change` columns. This makes it impossible to tell from monitoring whether the worker is idle, processing a tick, or stuck in a transaction.

Regular user backends get this for free via `tcop/postgres.c`. Background workers must do it themselves.

## Fix

Add `pgstat_report_activity` transitions around the inner work loop:

- `STATE_IDLE` initially (worker starts by waiting for a wake)
- `STATE_RUNNING` when the worker enters the inner work loop
- `STATE_IDLE` when the inner loop drains and the worker goes back to waiting

`cmd_str = NULL`, matching what other background workers do (logical replication apply worker, walsender on idle). `backend_type` already identifies the row as `"pg_net <ver> worker"`, so a query-column label would be redundant.

## Verification

Sample output before/after on a local repro:

**Before** (`backend_type ilike '%pg_net%'`):

```
 pid | backend_type         | state | wait_event
-----+----------------------+-------+-----------
 218 | pg_net 0.20.2 worker |       | Extension
```

**After, at rest:**

```
 pid | backend_type         | state | wait_event
-----+----------------------+-------+-----------
 218 | pg_net 0.20.2 worker | idle  | Extension
```

**After, while processing a tick:**

```
 pid | backend_type         | state  | wait_event
-----+----------------------+--------+-----------
 218 | pg_net 0.20.2 worker | active | Extension
```

Refs PSQL-1221, follow-up to #254.