### PR TITLE
bump to 0.20.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 EXTENSION = pg_net
-EXTVERSION = 0.20.2
+EXTVERSION = 0.20.3
 
 DATA = $(wildcard sql/*--*.sql)
 

--- a/sql/pg_net--0.20.2--0.20.3.sql
+++ b/sql/pg_net--0.20.2--0.20.3.sql
@@ -1,0 +1,1 @@
+-- no SQL changes in 0.20.3


### PR DESCRIPTION
## What kind of change does this PR introduce?

Picks up two fixes already on master:

   - #254 — flush pgstat counters from worker so autovacuum sees its writes
   - #255 — report worker activity to pg_stat_activity

No SQL changes (empty `sql/pg_net--0.20.2--0.20.3.sql`)
