### PR TITLE
Port pg_net to PostgreSQL 19

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -104,7 +104,11 @@ void init_curl_handle(CurlHandle *handle, RequestQueueRow row) {
   EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_TIMEOUT_MS, (long)handle->timeout_milliseconds);
   EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_PRIVATE, handle);
   EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_FOLLOWLOCATION, (long)true);
+#if PG_VERSION_NUM >= 190000
+  if (*log_min_messages <= DEBUG2) EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_VERBOSE, 1L);
+#else
   if (log_min_messages <= DEBUG2) EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_VERBOSE, 1L);
+#endif
 #if LIBCURL_VERSION_NUM >= 0x075500 /* libcurl 7.85.0 */
   EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_PROTOCOLS_STR, "http,https");
 #else
@@ -219,6 +223,24 @@ RequestQueueRow get_request_queue_row(HeapTuple spi_tupval, TupleDesc spi_tupdes
 static Jsonb *jsonb_headers_from_curl_handle(CURL *ez_handle) {
   struct curl_header *header, *prev = NULL;
 
+#if PG_VERSION_NUM >= 190000
+  JsonbInState headers = {0};
+  pushJsonbValue(&headers, WJB_BEGIN_OBJECT, NULL);
+
+  while ((header = curl_easy_nextheader(ez_handle, CURLH_HEADER, 0, prev))) {
+    JsonbValue key   = {.type = jbvString,
+                        .val  = {.string = {.val = header->name, .len = strlen(header->name)}}};
+    JsonbValue value = {.type = jbvString,
+                        .val  = {.string = {.val = header->value, .len = strlen(header->value)}}};
+    pushJsonbValue(&headers, WJB_KEY, &key);
+    pushJsonbValue(&headers, WJB_VALUE, &value);
+    prev = header;
+  }
+
+  pushJsonbValue(&headers, WJB_END_OBJECT, NULL);
+
+  return JsonbValueToJsonb(headers.result);
+#else
   JsonbParseState *headers = NULL;
   (void)pushJsonbValue(&headers, WJB_BEGIN_OBJECT, NULL);
 
@@ -235,6 +257,7 @@ static Jsonb *jsonb_headers_from_curl_handle(CURL *ez_handle) {
   Jsonb *jsonb_headers = JsonbValueToJsonb(pushJsonbValue(&headers, WJB_END_OBJECT, NULL));
 
   return jsonb_headers;
+#endif
 }
 
 void insert_response(CurlHandle *handle, CURLcode curl_return_code) {

--- a/src/event.c
+++ b/src/event.c
@@ -18,7 +18,7 @@ inline int wait_event(int fd, event *events, size_t maxevents, int timeout_milli
   return epoll_wait(fd, events, maxevents, timeout_milliseconds);
 }
 
-inline int event_monitor() {
+inline int event_monitor(void) {
   return epoll_create1(0);
 }
 
@@ -139,7 +139,7 @@ int inline wait_event(int fd, event *events, size_t maxevents, int timeout_milli
                 &(struct timespec){.tv_sec = timeout_milliseconds / 1000});
 }
 
-int inline event_monitor() {
+int inline event_monitor(void) {
   return kqueue();
 }
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -132,6 +132,9 @@ Datum wake(__attribute__((unused)) PG_FUNCTION_ARGS) {
 }
 
 static void handle_sigterm(__attribute__((unused)) SIGNAL_ARGS) {
+#if PG_VERSION_NUM >= 190000
+  (void) pg_siginfo;
+#endif
   int save_errno = errno;
   pg_atomic_write_u32(&worker_state->got_restart, 1);
   pg_write_barrier();
@@ -140,6 +143,9 @@ static void handle_sigterm(__attribute__((unused)) SIGNAL_ARGS) {
 }
 
 static void handle_sighup(__attribute__((unused)) SIGNAL_ARGS) {
+#if PG_VERSION_NUM >= 190000
+  (void) pg_siginfo;
+#endif
   int save_errno = errno;
   got_sighup     = true;
   if (worker_state->shared_latch) SetLatch(worker_state->shared_latch);
@@ -156,7 +162,11 @@ static void handle_sigusr1(SIGNAL_ARGS) {
   int save_errno = errno;
   if (worker_state->shared_latch) SetLatch(worker_state->shared_latch);
   errno = save_errno;
-  procsignal_sigusr1_handler(postgres_signal_arg);
+  procsignal_sigusr1_handler(postgres_signal_arg
+#if PG_VERSION_NUM >= 190000
+                             , pg_siginfo
+#endif
+                             );
 }
 
 static void publish_state(WorkerStatus s) {


### PR DESCRIPTION
- worker.c: silence -Werror=unused-parameter for the new pg_siginfo argument PG19 expanded SIGNAL_ARGS from one parameter (postgres_signal_arg) to two (postgres_signal_arg, pg_siginfo).  The existing __attribute__((unused)) prefix only silenced the first parameter.  Add a (void) cast guarded by PG_VERSION_NUM >= 190000 in handle_sigterm and handle_sighup.

- worker.c: pass both SIGNAL_ARGS arguments to procsignal_sigusr1_handler procsignal_sigusr1_handler() now matches the new SIGNAL_ARGS signature in PG19, so the forwarding call in handle_sigusr1 must supply pg_siginfo as the second argument.

- core.c: dereference log_min_messages under PG19 In PG19, log_min_messages changed from int to int* (GUC value moved to shared memory).  Comparing a pointer to the integer constant DEBUG2 is invalid; guard with a #if block that dereferences the pointer for PG19 and keeps the direct comparison for older releases.

- core.c: adapt jsonb_headers_from_curl_handle to the revised pushJsonbValue API PG19 replaced the (JsonbParseState **, ...) -> JsonbValue* overload with a new (JsonbInState *, ...) -> void signature.  The accumulated result is now stored in JsonbInState.result (a JsonbValue*) rather than being returned by the final WJB_END_OBJECT call.  Add a PG_VERSION_NUM >= 190000 branch that:
    * declares JsonbInState on the stack (zero-initialised with = {0})
    * passes &headers (JsonbInState*) to every pushJsonbValue call
    * calls JsonbValueToJsonb(headers.result) to obtain the final Jsonb* (headers.result is already JsonbValue*, so no & is needed) The old JsonbParseState** path is preserved in the #else branch.

- event.c: replace empty () with (void) in both event_monitor definitions GCC -Werror=old-style-definition rejects functions declared with () (which in C means "unspecified arguments", a K&R-era convention) when no parameters are intended.  Changed to (void) in both the epoll and kqueue variants.

Coded by Claude, tested by me.

Per: https://github.com/pgdg-packaging/pgdg-rpms/issues/213