### PR TITLE
build: could not build with pg versions older than 16 on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,17 @@ ifeq ($(CC),gcc)
 endif
 
 UNAME_S := $(shell uname -s)
+PG_CONFIG = pg_config
 
 ifeq ($(UNAME_S),Darwin)
-    SHARED_EXT  := dylib
+    # macOS switched the loadable-module extension from .so to .dylib in PG16
+    # So we check the postgres version to decide the correct extension to use
+    PG_MAJORVERSION := $(shell $(PG_CONFIG) --version | sed -E 's/PostgreSQL ([0-9]+).*/\1/')
+    ifeq ($(shell test $(PG_MAJORVERSION) -ge 16; echo $$?),0)
+        SHARED_EXT  := dylib
+    else
+        SHARED_EXT  := so
+    endif
 else
     SHARED_EXT  := so
 endif
@@ -45,7 +53,6 @@ else
 OBJS = $(patsubst $(SRC_DIR)/%.c, src/%.o, $(SRC)) # if no BUILD_DIR, just build on src so standard PGXS `make` works
 endif
 
-PG_CONFIG = pg_config
 SHLIB_LINK = -lcurl
 
 # Find <curl/curl.h> from system headers

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ UNAME_S := $(shell uname -s)
 PG_CONFIG = pg_config
 
 ifeq ($(UNAME_S),Darwin)
-    # macOS switched the loadable-module extension from .so to .dylib in PG16
+    # PG16 switched the loadable-module extension from .so to .dylib on macOS
     # So we check the postgres version to decide the correct extension to use
     PG_MAJORVERSION := $(shell $(PG_CONFIG) --version | sed -E 's/PostgreSQL ([0-9]+).*/\1/')
     ifeq ($(shell test $(PG_MAJORVERSION) -ge 16; echo $$?),0)


### PR DESCRIPTION
This PR fixes the build on macos for Postgres versions older than 16. Without this fix, when trying to run tests on such a version the build failed with this message:

```
$ xpg -v 12 test
make: *** No rule to make target 'pg_net.dylib', needed by 'build-12/pg_net.dylib'.  Stop.
```