### PR TITLE
test: fix flaky tests by replacing hardcoded sleeps with polls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,16 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
-
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg-version: ['12', '13', '14', '15', '16', '17', '18', '19']
+        pg-version: ["12", "13", "14", "15", "16", "17", "18", "19"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -23,16 +25,16 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build
-        run: nix-shell --run "xpg -v ${{ matrix.pg-version }} build"
+        run: nix-shell --argstr pgVersion "${{ matrix.pg-version }}" --arg cassert false --run "xpg -v ${{ matrix.pg-version }} build"
 
       - name: Run tests
-        run: nix-shell --run "xpg -v ${{ matrix.pg-version }} test"
+        run: nix-shell --argstr pgVersion "${{ matrix.pg-version }}" --arg cassert false --run "xpg -v ${{ matrix.pg-version }} test"
 
   test-on-macos:
     runs-on: macos-15
     strategy:
       matrix:
-        pg-version: ['17']
+        pg-version: ["17"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -48,16 +50,21 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build
-        run: nix-shell --run "xpg -v ${{ matrix.pg-version }} build"
+        run: nix-shell --argstr pgVersion "${{ matrix.pg-version }}" --arg cassert false --run "xpg -v ${{ matrix.pg-version }} build"
 
       - name: Run tests
-        run: nix-shell --run "xpg -v ${{ matrix.pg-version }} test"
+        run: nix-shell --argstr pgVersion "${{ matrix.pg-version }}" --arg cassert false --run "xpg -v ${{ matrix.pg-version }} test"
 
   loadtest:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        params: [ {reqs: 10000, batch: 200}, {reqs: 20000, batch: 400}, {reqs: 40000, batch: 800} ]
+        params:
+          [
+            { reqs: 10000, batch: 200 },
+            { reqs: 20000, batch: 400 },
+            { reqs: 40000, batch: 800 },
+          ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -71,19 +78,18 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build
-        run: nix-shell --run "xpg build"
+        run: nix-shell --argstr pgVersion "17" --arg cassert false --run "xpg build"
 
       - name: Run load test
         run: |
-          nix-shell --run "net-loadtest ${{ matrix.params.reqs }} ${{ matrix.params.batch }}" >> "$GITHUB_STEP_SUMMARY"
+          nix-shell --argstr pgVersion "17" --arg cassert false --run "net-loadtest ${{ matrix.params.reqs }} ${{ matrix.params.batch }}" >> "$GITHUB_STEP_SUMMARY"
 
   coverage:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        pg-version: ['17']
+        pg-version: ["17"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -98,7 +104,7 @@ jobs:
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Coverage
-        run: nix-shell --run "xpg -v ${{ matrix.pg-version }} coverage"
+        run: nix-shell --argstr pgVersion "${{ matrix.pg-version }}" --arg cassert false --run "xpg -v ${{ matrix.pg-version }} coverage"
 
       - name: Send coverage to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
@@ -107,7 +113,6 @@ jobs:
           files: ./build-${{ matrix.pg-version }}/coverage.info
 
   style:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,14 +1,16 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches: [master]
 
 jobs:
-
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg-version: ['12', '13', '14', '15', '16', '17', '18', '19']
+        pg-version: ["12", "13", "14", "15", "16", "17", "18", "19"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -32,7 +34,7 @@ jobs:
     runs-on: macos-15
     strategy:
       matrix:
-        pg-version: ['17']
+        pg-version: ["17"]
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
@@ -57,7 +59,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        params: [ {reqs: 10000, batch: 200}, {reqs: 20000, batch: 400}, {reqs: 40000, batch: 800} ]
+        params:
+          [
+            { reqs: 10000, batch: 200 },
+            { reqs: 20000, batch: 400 },
+            { reqs: 40000, batch: 800 },
+          ]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -78,12 +85,11 @@ jobs:
           nix-shell --run "net-loadtest ${{ matrix.params.reqs }} ${{ matrix.params.batch }}" >> "$GITHUB_STEP_SUMMARY"
 
   coverage:
-
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
-        pg-version: ['17']
+        pg-version: ["17"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -107,7 +113,6 @@ jobs:
           files: ./build-${{ matrix.pg-version }}/coverage.info
 
   style:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,15 @@ $ xpg -v 13 test
 
 This will spawn a local db and an nginx server for testing.
 
+To run a single test , set `PYTEST_ARGS` to `-k test_function_name`. For example:
+
+```bash
+$ nix develop
+$ PYTEST_ARGS="-k test_connect" xpg test
+```
+
+Will run the `test_connect` test only. `PYTEST_ARGS` is passed through to pytest, so you can pass other arguments to pytest as well.
+
 ### Debugging
 
 You can turn on logging level to see curl traces with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,15 @@ $ nix develop
 $ PYTEST_ARGS="-k test_connect" xpg test
 ```
 
-Will run the `test_connect` test only. `PYTEST_ARGS` is passed through to pytest, so you can pass other arguments to pytest as well.
+Will run the `test_connect` test only. `PYTEST_ARGS` is passed through to pytest, so you can pass other arguments to pytest as well. in fact you can pass any args via `PYTEST_ARGS`. You can e.g. run all tests in a file:
+
+```bash
+$ nix develop
+$ PYTEST_ARGS="PYTEST_ARGS="test/test_user_db.py" xpg test
+```
+
+Will run tests in `test/test_user_db.py`, or:
+
 
 ### Debugging
 

--- a/Makefile
+++ b/Makefile
@@ -85,4 +85,4 @@ include $(PGXS)
 
 .PHONY: test
 test:
-	net-with-nginx python -m pytest -s -vv
+	net-with-nginx python -m pytest -s -vv $(PYTEST_ARGS)

--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1782266378,
-        "narHash": "sha256-moRjdGvymGEyREU4++qpNzDuUN+nVC69CUYjhuY4Yzs=",
+        "lastModified": 1785529904,
+        "narHash": "sha256-DDIeJCHRtmvB7yocWTo1MISIGf0DsUmyLw6ISuEV4e0=",
         "owner": "steve-chavez",
         "repo": "xpg",
-        "rev": "d81725666a193c644fe0db96a988ece66edf460c",
+        "rev": "e7d47eb58f19168b5facc6b78a64f6cc7f04bbcb",
         "type": "github"
       },
       "original": {
         "owner": "steve-chavez",
-        "ref": "v2.4.0",
+        "ref": "v2.5.0",
         "repo": "xpg",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     # 2025-11-13
     nixpkgs.url = "github:NixOS/nixpkgs/91c9a64ce2a84e648d0cf9671274bb9c2fb9ba60";
     xpg = {
-      url = "github:steve-chavez/xpg/v2.4.0";
+      url = "github:steve-chavez/xpg/v2.5.0";
     };
   };
 

--- a/shell.nix
+++ b/shell.nix
@@ -14,6 +14,8 @@ in
     inherit (xpgLock) owner repo rev;
     sha256 = xpgLock.narHash;
   })
+, pgVersion ? null
+, cassert ? true
 }:
 let
   nginxCustom = pkgs.callPackage ./nix/nginxCustom.nix {};
@@ -36,7 +38,7 @@ in
 pkgs.mkShell {
   buildInputs =
     [
-      xpgPkgs.xpg
+      (if pgVersion == null then xpgPkgs.xpg else xpgPkgs.xpg.forVersions { versions = [ pgVersion ]; inherit cassert; })
       pythonDeps
       nginxCustom.nginxScript
       pkgs.curlWithGnuTls

--- a/test/common.py
+++ b/test/common.py
@@ -1,0 +1,329 @@
+import time
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
+
+
+def http_request(sess, query):
+    """
+    Execute query and commit to wake up the background worker.
+
+    The query should return a single row with a single column
+    containing the request id of the request. Returns the request
+    id
+    """
+    request_id = sess.execute(query).scalar_one()
+    # Commit to wakeup background worker
+    sess.commit()
+    return request_id
+
+
+def http_requests(sess, query):
+    """
+    Execute query and commit to wake up the background worker.
+
+    The query usually contains multiple http requests. Returns
+    the reqeust id of the first request in the query
+    """
+    (request_id,) = sess.execute(query).first()
+    # Commit to wakeup background worker
+    sess.commit()
+    return request_id
+
+
+def collect_response_sync(sess, request_id):
+    """
+    Wait for request with request_id to complete and return its response.
+
+    Flattens net._http_collect_response's nested composite return type
+    (status, message, response(status_code, headers, body)) into a single
+    row, so callers get a name-addressable mapping (e.g. result["body"])
+    instead of indexing into a stringified nested tuple.
+    """
+    return sess.execute(
+        text(
+            """
+        select
+            status,
+            message,
+            (response).status_code,
+            (response).headers,
+            (response).body
+        from net._http_collect_response(:request_id, async:=false);
+    """
+        ),
+        {"request_id": request_id},
+    ).mappings().fetchone()
+
+
+def is_worker_up(autocommit_sess):
+    """
+    Returns a function that checks whether worker is up or not
+
+    The returned function captures autocommit_sess argument and
+    uses it to track worker status. 
+    """
+
+    def fetch():
+        (worker_is_up,) = autocommit_sess.execute(
+            text("select is_worker_up();")
+        ).fetchone()
+        return worker_is_up
+    return fetch
+
+
+def get_queue_length(autocommit_sess):
+    """
+    Returns a function that returns the queue length
+
+    The returned function captures autocommit_sess argument and
+    uses it to track queue length. 
+    """
+
+    def fetch():
+        (queue_length,) = autocommit_sess.execute(text("""
+            select count(*) from net.http_request_queue;
+        """)).fetchone()
+        return queue_length
+    return fetch
+
+
+def get_response_count(autocommit_sess):
+    """
+    Returns a function that returns the number of rows in net._http_response table
+
+    The returned function captures autocommit_sess argument and
+    uses it to run the sql query. 
+    """
+
+    def fetch():
+        (response_count,) = autocommit_sess.execute(text("""
+            select count(*) from net._http_response;
+        """)).fetchone()
+        return response_count
+    return fetch
+
+
+def get_worker_state(autocommit_sess):
+    """
+    Returns a function that returns the background worker state
+
+    The returned function captures autocommit_sess argument and
+    uses it to run the sql query. 
+    """
+
+    def fetch():
+        (state,) = autocommit_sess.execute(text("""
+            select state from pg_stat_activity where backend_type ilike '%pg_net%';
+        """)).fetchone()
+        return state
+    return fetch
+
+
+def is_extension_installed(autocommit_sess):
+    """
+    Returns a function that returns whether pg_net is installed or not
+
+    The returned function captures autocommit_sess argument and
+    uses it to run the sql query. 
+    """
+
+    def fetch():
+        (extension_installed,) = autocommit_sess.execute(text("""
+            select count(*) = 1 from pg_extension where extname = 'pg_net';
+        """)).fetchone()
+        return extension_installed
+    return fetch
+
+
+def try_connect(engine, tmp_sess):
+    """
+    Returns a function that return whether postgres can accept connections.
+    """
+
+    def fetch():
+        try:
+            engine = create_engine("postgresql:///postgres")
+            ac_engine = engine.execution_options(
+                isolation_level="AUTOCOMMIT")
+            tmp_sess = Session(ac_engine)
+            return tmp_sess.execute(text("select 1")).fetchone()
+        except Exception:
+            return None
+    return fetch
+
+
+def wait_for_worker_down(autocommit_sess):
+    """
+    Waits until worker goes down
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        is_worker_up(autocommit_sess),
+        lambda worker_is_up: not worker_is_up,
+        description="background worker to go down",
+    )
+
+
+def wait_for_worker_up(autocommit_sess):
+    """
+    Waits until worker comes up
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        is_worker_up(autocommit_sess),
+        lambda worker_is_up: worker_is_up,
+        description="background worker to come up",
+    )
+
+
+def wait_for_worker_state(autocommit_sess, expected_state):
+    """
+    Waits until worker state matches expected_state
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        get_worker_state(autocommit_sess),
+        lambda state: state == expected_state,
+        description=f"background worker state to become {expected_state}",
+    )
+
+
+def wait_for_queue_drain(autocommit_sess):
+    """
+    Waits until the request queue is empty
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        get_queue_length(autocommit_sess),
+        lambda queue_length: queue_length == 0,
+        description="queue to drain"
+    )
+
+
+def wait_for_response_count(autocommit_sess, expected_count):
+    """
+    Waits until number of rows in net._http_response match expected_count
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        get_response_count(autocommit_sess),
+        lambda response_count: response_count == expected_count,
+        description="all responses to arrive"
+    )
+
+
+def wait_for_any_response(autocommit_sess):
+    """
+    Waits for at least one row in in net._http_response
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        get_response_count(autocommit_sess),
+        lambda response_count: response_count > 0,
+        description="any response to arrive"
+    )
+
+
+def wait_for_extension_drop(autocommit_sess):
+    """
+    Waits for pg_net to be dropped
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        is_extension_installed(autocommit_sess),
+        lambda extension_installed: not extension_installed,
+        description="extension to be dropped"
+    )
+
+
+def wait_for_postgres_ready(engine, tmp_sess):
+    """
+    Waits for postgres to be ready to accept connections
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        try_connect(engine, tmp_sess),
+        lambda result: result is not None,
+        description="postgres to become ready"
+    )
+
+
+def wait_until(fetch, predicate, timeout=10, sleep_interval=0.1, description="condition"):
+    deadline = time.time() + timeout
+    result = None
+    while time.time() < deadline:
+        result = fetch()
+        if predicate(result):
+            return result
+        time.sleep(sleep_interval)
+    raise AssertionError(
+        f"Timed out after {timeout}s waiting for {description} (last value: {result!r})"
+    )
+
+
+def wakeup_worker(sess):
+    """
+    Wakes up the worker manually by calling net.wake() and committing
+    """
+
+    sess.execute(text("select net.wake()"))
+    sess.commit()  # commit so worker  wakes
+
+
+def restart_worker(sess):
+    """
+    Restarts the worker and waits for it to come back up
+
+    You'd think that the following implementation should
+    restart the worker and wait for it to come back up:
+
+    sess.execute(text("select net.worker_restart()"))
+    sess.execute(text("select net.wait_until_running()"))
+
+    But it has a race condition in which this function might
+    return before the worker has restarted. This happens because
+    net.worker_restart() returns immediately after setting a flag
+    to indicate to the core worker loop to restart. Then the
+    net.wait_until_running() function waits for the worker state to
+    become WS_RUNNING. But it can read the state from either the worker
+    before the restart or after. In the first case it returns before
+    the worker has restarted properly, and in the second case it
+    behaves correctly.
+
+    Instead we compare the pids of the workers before and after the
+    restart which guarantees that the worker has restarted. After the
+    restart we still run net.wait_until_running() for it to be
+    intialized properly.
+    """
+
+    def fetch_worker_pid():
+        return sess.execute(text("""
+            select pid from pg_stat_activity where backend_type ilike '%pg_net%';
+        """)).scalar()
+
+    old_pid = fetch_worker_pid()
+    sess.execute(text("select net.worker_restart()"))
+    wait_until(
+        fetch_worker_pid,
+        lambda pid: pid is not None and pid != old_pid,
+        description="background worker to restart with a new pid",
+    )
+    # the new worker's pg_stat_activity row appears slightly before it
+    # publishes WS_RUNNING, so also wait for it to be fully up
+    sess.execute(text("select net.wait_until_running()"))

--- a/test/common.py
+++ b/test/common.py
@@ -6,8 +6,25 @@ from sqlalchemy.orm import Session
 def http_request(sess, query):
     """
     Execute query and commit to wake up the background worker.
+
+    The query should return a single row with a single column
+    containing the request id of the request. Returns the request
+    id
     """
-    (request_id,) = sess.execute(query).fetchone()
+    request_id = sess.execute(query).scalar_one()
+    # Commit to wakeup background worker
+    sess.commit()
+    return request_id
+
+
+def http_requests(sess, query):
+    """
+    Execute query and commit to wake up the background worker.
+
+    The query usually contains multiple http requests. Returns
+    the reqeust id of the first request in the query
+    """
+    (request_id,) = sess.execute(query).first()
     # Commit to wakeup background worker
     sess.commit()
     return request_id
@@ -259,6 +276,7 @@ def wait_until(fetch, predicate, timeout=10, sleep_interval=0.1, description="co
         f"Timed out after {timeout}s waiting for {description} (last value: {result!r})"
     )
 
+
 def wakeup_worker(sess):
     """
     Wakes up the worker manually by calling net.wake() and committing
@@ -266,6 +284,7 @@ def wakeup_worker(sess):
 
     sess.execute(text("select net.wake()"))
     sess.commit()  # commit so worker  wakes
+
 
 def restart_worker(sess):
     """
@@ -308,4 +327,3 @@ def restart_worker(sess):
     # the new worker's pg_stat_activity row appears slightly before it
     # publishes WS_RUNNING, so also wait for it to be fully up
     sess.execute(text("select net.wait_until_running()"))
-    

--- a/test/common.py
+++ b/test/common.py
@@ -1,0 +1,25 @@
+from sqlalchemy import text
+
+
+def collect_response_sync(sess, request_id):
+    """Wait for request with request_id to complete and return its response.
+
+    Flattens net._http_collect_response's nested composite return type
+    (status, message, response(status_code, headers, body)) into a single
+    row, so callers get a name-addressable mapping (e.g. result["body"])
+    instead of indexing into a stringified nested tuple.
+    """
+    return sess.execute(
+        text(
+            """
+        select
+            status,
+            message,
+            (response).status_code,
+            (response).headers,
+            (response).body
+        from net._http_collect_response(:request_id, async:=false);
+    """
+        ),
+        {"request_id": request_id},
+    ).mappings().fetchone()

--- a/test/common.py
+++ b/test/common.py
@@ -258,3 +258,11 @@ def wait_until(fetch, predicate, timeout=10, sleep_interval=0.1, description="co
     raise AssertionError(
         f"Timed out after {timeout}s waiting for {description} (last value: {result!r})"
     )
+
+def wakeup_worker(sess):
+    """
+    Wakes up the worker manually by calling net.wake() and committing
+    """
+
+    sess.execute(text("select net.wake()"))
+    sess.commit()  # commit so worker  wakes

--- a/test/common.py
+++ b/test/common.py
@@ -1,5 +1,6 @@
 import time
-from sqlalchemy import text
+from sqlalchemy import create_engine, text
+from sqlalchemy.orm import Session
 
 
 def http_request(sess, query):
@@ -35,6 +36,216 @@ def collect_response_sync(sess, request_id):
         ),
         {"request_id": request_id},
     ).mappings().fetchone()
+
+
+def is_worker_up(autocommit_sess):
+    """
+    Returns a function that checks whether worker is up or not
+
+    The returned function captures autocommit_sess argument and
+    uses it to track worker status. 
+    """
+
+    def fetch():
+        (worker_is_up,) = autocommit_sess.execute(
+            text("select is_worker_up();")
+        ).fetchone()
+        return worker_is_up
+    return fetch
+
+
+def get_queue_length(autocommit_sess):
+    """
+    Returns a function that returns the queue length
+
+    The returned function captures autocommit_sess argument and
+    uses it to track queue length. 
+    """
+
+    def fetch():
+        (queue_length,) = autocommit_sess.execute(text("""
+            select count(*) from net.http_request_queue;
+        """)).fetchone()
+        return queue_length
+    return fetch
+
+
+def get_response_count(autocommit_sess):
+    """
+    Returns a function that returns the number of rows in net._http_response table
+
+    The returned function captures autocommit_sess argument and
+    uses it to run the sql query. 
+    """
+
+    def fetch():
+        (response_count,) = autocommit_sess.execute(text("""
+            select count(*) from net._http_response;
+        """)).fetchone()
+        return response_count
+    return fetch
+
+
+def get_worker_state(autocommit_sess):
+    """
+    Returns a function that returns the background worker state
+
+    The returned function captures autocommit_sess argument and
+    uses it to run the sql query. 
+    """
+
+    def fetch():
+        (state,) = autocommit_sess.execute(text("""
+            select state from pg_stat_activity where backend_type ilike '%pg_net%';
+        """)).fetchone()
+        return state
+    return fetch
+
+
+def is_extension_installed(autocommit_sess):
+    """
+    Returns a function that returns whether pg_net is installed or not
+
+    The returned function captures autocommit_sess argument and
+    uses it to run the sql query. 
+    """
+
+    def fetch():
+        (extension_installed,) = autocommit_sess.execute(text("""
+            select count(*) = 1 from pg_extension where extname = 'pg_net';
+        """)).fetchone()
+        return extension_installed
+    return fetch
+
+
+def try_connect(engine, tmp_sess):
+    """
+    Returns a function that return whether postgres can accept connections.
+    """
+
+    def fetch():
+        try:
+            engine = create_engine("postgresql:///postgres")
+            ac_engine = engine.execution_options(
+                isolation_level="AUTOCOMMIT")
+            tmp_sess = Session(ac_engine)
+            return tmp_sess.execute(text("select 1")).fetchone()
+        except Exception:
+            return None
+    return fetch
+
+
+def wait_for_worker_down(autocommit_sess):
+    """
+    Waits until worker goes down
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        is_worker_up(autocommit_sess),
+        lambda worker_is_up: not worker_is_up,
+        description="background worker to go down",
+    )
+
+
+def wait_for_worker_up(autocommit_sess):
+    """
+    Waits until worker comes up
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        is_worker_up(autocommit_sess),
+        lambda worker_is_up: worker_is_up,
+        description="background worker to come up",
+    )
+
+
+def wait_for_worker_state(autocommit_sess, expected_state):
+    """
+    Waits until worker state matches expected_state
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        get_worker_state(autocommit_sess),
+        lambda state: state == expected_state,
+        description=f"background worker state to become {expected_state}",
+    )
+
+
+def wait_for_queue_drain(autocommit_sess):
+    """
+    Waits until the request queue is empty
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        get_queue_length(autocommit_sess),
+        lambda queue_length: queue_length == 0,
+        description="queue to drain"
+    )
+
+
+def wait_for_response_count(autocommit_sess, expected_count):
+    """
+    Waits until number of rows in net._http_response match expected_count
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        get_response_count(autocommit_sess),
+        lambda response_count: response_count == expected_count,
+        description="all responses to arrive"
+    )
+
+
+def wait_for_any_response(autocommit_sess):
+    """
+    Waits for at least one row in in net._http_response
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        get_response_count(autocommit_sess),
+        lambda response_count: response_count > 0,
+        description="any response to arrive"
+    )
+
+
+def wait_for_extension_drop(autocommit_sess):
+    """
+    Waits for pg_net to be dropped
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        is_extension_installed(autocommit_sess),
+        lambda extension_installed: not extension_installed,
+        description="extension to be dropped"
+    )
+
+
+def wait_for_postgres_ready(engine, tmp_sess):
+    """
+    Waits for postgres to be ready to accept connections
+
+    Or throws an error if it doesn't within a timeout
+    """
+
+    wait_until(
+        try_connect(engine, tmp_sess),
+        lambda result: result is not None,
+        description="postgres to become ready"
+    )
+
 
 def wait_until(fetch, predicate, timeout=10, sleep_interval=0.1, description="condition"):
     deadline = time.time() + timeout

--- a/test/common.py
+++ b/test/common.py
@@ -7,10 +7,10 @@ def http_request(sess, query):
     """
     Execute query and commit to wake up the background worker.
     """
-    result = sess.execute(query).fetchone()
+    (request_id,) = sess.execute(query).fetchone()
     # Commit to wakeup background worker
     sess.commit()
-    return result
+    return request_id
 
 
 def collect_response_sync(sess, request_id):

--- a/test/common.py
+++ b/test/common.py
@@ -266,3 +266,46 @@ def wakeup_worker(sess):
 
     sess.execute(text("select net.wake()"))
     sess.commit()  # commit so worker  wakes
+
+def restart_worker(sess):
+    """
+    Restarts the worker and waits for it to come back up
+
+    You'd think that the following implementation should
+    restart the worker and wait for it to come back up:
+
+    sess.execute(text("select net.worker_restart()"))
+    sess.execute(text("select net.wait_until_running()"))
+
+    But it has a race condition in which this function might
+    return before the worker has restarted. This happens because
+    net.worker_restart() returns immediately after setting a flag
+    to indicate to the core worker loop to restart. Then the
+    net.wait_until_running() function waits for the worker state to
+    become WS_RUNNING. But it can read the state from either the worker
+    before the restart or after. In the first case it returns before
+    the worker has restarted properly, and in the second case it
+    behaves correctly.
+
+    Instead we compare the pids of the workers before and after the
+    restart which guarantees that the worker has restarted. After the
+    restart we still run net.wait_until_running() for it to be
+    intialized properly.
+    """
+
+    def fetch_worker_pid():
+        return sess.execute(text("""
+            select pid from pg_stat_activity where backend_type ilike '%pg_net%';
+        """)).scalar()
+
+    old_pid = fetch_worker_pid()
+    sess.execute(text("select net.worker_restart()"))
+    wait_until(
+        fetch_worker_pid,
+        lambda pid: pid is not None and pid != old_pid,
+        description="background worker to restart with a new pid",
+    )
+    # the new worker's pg_stat_activity row appears slightly before it
+    # publishes WS_RUNNING, so also wait for it to be fully up
+    sess.execute(text("select net.wait_until_running()"))
+    

--- a/test/common.py
+++ b/test/common.py
@@ -1,6 +1,16 @@
 from sqlalchemy import text
 
 
+def http_request(sess, query):
+    """
+    Execute query and commit to wake up the background worker.
+    """
+    result = sess.execute(query).fetchone()
+    # Commit to wakeup background worker
+    sess.commit()
+    return result
+
+
 def collect_response_sync(sess, request_id):
     """
     Wait for request with request_id to complete and return its response.

--- a/test/common.py
+++ b/test/common.py
@@ -1,3 +1,4 @@
+import time
 from sqlalchemy import text
 
 
@@ -34,3 +35,15 @@ def collect_response_sync(sess, request_id):
         ),
         {"request_id": request_id},
     ).mappings().fetchone()
+
+def wait_until(fetch, predicate, timeout=10, sleep_interval=0.1, description="condition"):
+    deadline = time.time() + timeout
+    result = None
+    while time.time() < deadline:
+        result = fetch()
+        if predicate(result):
+            return result
+        time.sleep(sleep_interval)
+    raise AssertionError(
+        f"Timed out after {timeout}s waiting for {description} (last value: {result!r})"
+    )

--- a/test/common.py
+++ b/test/common.py
@@ -2,7 +2,8 @@ from sqlalchemy import text
 
 
 def collect_response_sync(sess, request_id):
-    """Wait for request with request_id to complete and return its response.
+    """
+    Wait for request with request_id to complete and return its response.
 
     Flattens net._http_collect_response's nested composite return type
     (status, message, response(status_code, headers, body)) into a single

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 
+
 @pytest.fixture(scope="function")
 def engine():
     engine = create_engine("postgresql:///postgres")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -44,26 +44,3 @@ def autocommit_sess(engine):
     session = Session(ac_engine)
 
     yield session
-
-
-@pytest.fixture(scope="function")
-def wait_until():
-    """Poll `fetch()` until `predicate(result)` is true, instead of a fixed sleep.
-
-    Returns the last fetched value on success, so callers can use it directly.
-    Raises AssertionError with the last observed value if `timeout` is exceeded.
-    """
-
-    def _wait_until(fetch, predicate, timeout=10, sleep_interval=0.1, description="condition"):
-        deadline = time.time() + timeout
-        result = None
-        while time.time() < deadline:
-            result = fetch()
-            if predicate(result):
-                return result
-            time.sleep(sleep_interval)
-        raise AssertionError(
-            f"Timed out after {timeout}s waiting for {description} (last value: {result!r})"
-        )
-
-    return _wait_until

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
@@ -42,3 +44,26 @@ def autocommit_sess(engine):
     session = Session(ac_engine)
 
     yield session
+
+
+@pytest.fixture(scope="function")
+def wait_until():
+    """Poll `fetch()` until `predicate(result)` is true, instead of a fixed sleep.
+
+    Returns the last fetched value on success, so callers can use it directly.
+    Raises AssertionError with the last observed value if `timeout` is exceeded.
+    """
+
+    def _wait_until(fetch, predicate, timeout=10, sleep_interval=0.1, description="condition"):
+        deadline = time.time() + timeout
+        result = None
+        while time.time() < deadline:
+            result = fetch()
+            if predicate(result):
+                return result
+            time.sleep(sleep_interval)
+        raise AssertionError(
+            f"Timed out after {timeout}s waiting for {description} (last value: {result!r})"
+        )
+
+    return _wait_until

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -1,5 +1,8 @@
 from sqlalchemy import text
 
+
 def test_connect(sess):
+    """Sanity test verifying connection to postgres works"""
+
     (x,) = sess.execute(text("select 1")).fetchone()
     assert x == 1

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -1,5 +1,6 @@
 from sqlalchemy import text
 
 def test_connect(sess):
+    """sanity test checking that connection to postgres works"""
     (x,) = sess.execute(text("select 1")).fetchone()
     assert x == 1

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -2,9 +2,7 @@ from sqlalchemy import text
 
 
 def test_connect(sess):
-    """
-    Sanity test checking that connection to postgres works
-    """
+    """Sanity test verifying connection to postgres works"""
 
     (x,) = sess.execute(text("select 1")).fetchone()
     assert x == 1

--- a/test/test_engine.py
+++ b/test/test_engine.py
@@ -1,6 +1,10 @@
 from sqlalchemy import text
 
+
 def test_connect(sess):
-    """sanity test checking that connection to postgres works"""
+    """
+    Sanity test checking that connection to postgres works
+    """
+
     (x,) = sess.execute(text("select 1")).fetchone()
     assert x == 1

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -1,24 +1,26 @@
+import json
 from sqlalchemy import text
+from common import collect_response_sync, http_request
+
 
 def test_http_delete_returns_id(sess):
-    """net.http_delete returns a bigint id"""
+    """Test net.http_delete returns an id"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/delete'
         );
     """
-    )).fetchone()
+    ))
 
     assert request_id == 1
 
 
 def test_http_delete_collect_sync_success(sess):
-    """test net.http_delete works"""
+    """Test net.http_delete works"""
 
-    # Create a request
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             url:='http://localhost:8080/delete'
@@ -26,86 +28,59 @@ def test_http_delete_collect_sync_success(sess):
         ,   headers:= '{"X-Baz": "foo"}'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
-
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
-    assert response[2] is not None
-    assert "X-Baz" in response[2]
-    assert "param-foo" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
+
+    # /delete endpoint returns params and headers in the response body
+    assert response["body"] is not None
+    assert "X-Baz" in response["body"]
+    assert "param-foo" in response["body"]
 
 
 def test_http_delete_positional_args(sess):
-    """test net.http_delete works with positional arguments. This to ensure backwards compat when a new parameter is added to the function."""
+    """
+    Test net.http_delete works with positional arguments.
+    This to ensure backwards compat when a new parameter is added to the function.
+    """
 
-    (request_id,) = sess.execute(text(
+    # Delete call with url only
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
-
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
 
-
-    (request_id,) = sess.execute(text(
+    # Delete call with url and params
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete',
             '{"param-foo": "bar"}'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
-
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
 
-
-    (request_id,) = sess.execute(text(
+    # Delete call with url, params, and headers
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete',
@@ -113,27 +88,16 @@ def test_http_delete_positional_args(sess):
             '{"X-Baz": "foo"}'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
-
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
 
-
-    (request_id,) = sess.execute(text(
+    # Delete call with url, params, headers, and timeout
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete',
@@ -142,53 +106,29 @@ def test_http_delete_positional_args(sess):
             5000
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
-
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
 
 
 def test_http_delete_with_body(sess):
-    """delete with request body works"""
+    """Test delete with request body works"""
 
-    # Create a request
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             url  :='http://localhost:8080/delete_w_body'
         ,   body := '{"key": "val"}'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the response, waiting as needed
-    (response_json,) = sess.execute(
-        text(
-            """
-        select
-            ((x.response).body)::jsonb body_json
-        from
-            net._http_collect_response(:request_id, async:=false) x;
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
-
-    assert response_json["key"] == "val"
+    assert response is not None
+    assert response["body"] is not None
+    assert json.loads(response["body"])["key"] == "val"

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -45,7 +45,10 @@ def test_http_delete_collect_sync_success(sess):
 
 
 def test_http_delete_positional_args(sess):
-    """test net.http_delete works with positional arguments. This to ensure backwards compat when a new parameter is added to the function."""
+    """
+    Test net.http_delete works with positional arguments.
+    This to ensure backwards compat when a new parameter is added to the function.
+    """
 
     (request_id,) = sess.execute(text(
         """
@@ -59,18 +62,11 @@ def test_http_delete_positional_args(sess):
     sess.commit()
 
     # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
 
 
     (request_id,) = sess.execute(text(
@@ -86,18 +82,11 @@ def test_http_delete_positional_args(sess):
     sess.commit()
 
     # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
 
 
     (request_id,) = sess.execute(text(
@@ -114,18 +103,11 @@ def test_http_delete_positional_args(sess):
     sess.commit()
 
     # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
 
 
     (request_id,) = sess.execute(text(
@@ -143,18 +125,11 @@ def test_http_delete_positional_args(sess):
     sess.commit()
 
     # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
 
 
 def test_http_delete_with_body(sess):
@@ -174,16 +149,16 @@ def test_http_delete_with_body(sess):
     sess.commit()
 
     # Collect the response, waiting as needed
-    (response_json,) = sess.execute(
+    response = sess.execute(
         text(
             """
         select
-            ((x.response).body)::jsonb body_json
+            ((response).body)::jsonb body_json
         from
-            net._http_collect_response(:request_id, async:=false) x;
+            net._http_collect_response(:request_id, async:=false);
     """
         ),
         {"request_id": request_id},
-        ).fetchone()
+        ).mappings().fetchone()
 
-    assert response_json["key"] == "val"
+    assert response["body_json"]["key"] == "val"

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -32,7 +32,7 @@ def test_http_delete_collect_sync_success(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -59,7 +59,7 @@ def test_http_delete_positional_args(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -77,7 +77,7 @@ def test_http_delete_positional_args(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -96,7 +96,7 @@ def test_http_delete_positional_args(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -116,7 +116,7 @@ def test_http_delete_positional_args(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -139,7 +139,7 @@ def test_http_delete_with_body(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -49,6 +49,7 @@ def test_http_delete_positional_args(sess):
     This to ensure backwards compat when a new parameter is added to the function.
     """
 
+    # Delete call with url only
     (request_id,) = http_request(sess, text(
         """
         select net.http_delete(
@@ -63,6 +64,7 @@ def test_http_delete_positional_args(sess):
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
 
+    # Delete call with url and params
     (request_id,) = http_request(sess, text(
         """
         select net.http_delete(
@@ -78,6 +80,7 @@ def test_http_delete_positional_args(sess):
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
 
+    # Delete call with url, params, and headers
     (request_id,) = http_request(sess, text(
         """
         select net.http_delete(
@@ -94,6 +97,7 @@ def test_http_delete_positional_args(sess):
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
 
+    # Delete call with url, params, headers, and timeout
     (request_id,) = http_request(sess, text(
         """
         select net.http_delete(
@@ -115,7 +119,6 @@ def test_http_delete_positional_args(sess):
 def test_http_delete_with_body(sess):
     """Test delete with request body works"""
 
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_delete(

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -1,7 +1,7 @@
 import json
 
 from sqlalchemy import text
-from common import collect_response_sync
+from common import collect_response_sync, http_request
 
 
 def test_http_delete_returns_id(sess):
@@ -21,8 +21,7 @@ def test_http_delete_returns_id(sess):
 def test_http_delete_collect_sync_success(sess):
     """Test net.http_delete works"""
 
-    # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_delete(
             url:='http://localhost:8080/delete'
@@ -30,16 +29,15 @@ def test_http_delete_collect_sync_success(sess):
         ,   headers:= '{"X-Baz": "foo"}'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
     assert response is not None
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
+
+    # /delete endpoint returns params and headers in the response body
     assert response["body"] is not None
     assert "X-Baz" in response["body"]
     assert "param-foo" in response["body"]
@@ -51,16 +49,13 @@ def test_http_delete_positional_args(sess):
     This to ensure backwards compat when a new parameter is added to the function.
     """
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -68,17 +63,14 @@ def test_http_delete_positional_args(sess):
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete',
             '{"param-foo": "bar"}'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -86,7 +78,7 @@ def test_http_delete_positional_args(sess):
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete',
@@ -94,10 +86,7 @@ def test_http_delete_positional_args(sess):
             '{"X-Baz": "foo"}'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -105,7 +94,7 @@ def test_http_delete_positional_args(sess):
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete',
@@ -114,10 +103,7 @@ def test_http_delete_positional_args(sess):
             5000
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -130,17 +116,14 @@ def test_http_delete_with_body(sess):
     """Test delete with request body works"""
 
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_delete(
             url  :='http://localhost:8080/delete_w_body'
         ,   body := '{"key": "val"}'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -3,7 +3,7 @@ from common import collect_response_sync
 
 
 def test_http_delete_returns_id(sess):
-    """net.http_delete returns a bigint id"""
+    """Test net.http_delete returns an id"""
 
     (request_id,) = sess.execute(text(
         """
@@ -17,7 +17,7 @@ def test_http_delete_returns_id(sess):
 
 
 def test_http_delete_collect_sync_success(sess):
-    """test net.http_delete works"""
+    """Test net.http_delete works"""
 
     # Create a request
     (request_id,) = sess.execute(text(
@@ -130,7 +130,7 @@ def test_http_delete_positional_args(sess):
 
 
 def test_http_delete_with_body(sess):
-    """delete with request body works"""
+    """Test delete with request body works"""
 
     # Create a request
     (request_id,) = sess.execute(text(

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -33,7 +33,6 @@ def test_http_delete_collect_sync_success(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
     response = collect_response_sync(sess, request_id)
 
     assert response is not None
@@ -61,7 +60,6 @@ def test_http_delete_positional_args(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
     response = collect_response_sync(sess, request_id)
 
     assert response is not None
@@ -80,7 +78,6 @@ def test_http_delete_positional_args(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
     response = collect_response_sync(sess, request_id)
 
     assert response is not None

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -1,3 +1,5 @@
+import json
+
 from sqlalchemy import text
 from common import collect_response_sync
 
@@ -97,7 +99,6 @@ def test_http_delete_positional_args(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
     response = collect_response_sync(sess, request_id)
 
     assert response is not None
@@ -118,7 +119,6 @@ def test_http_delete_positional_args(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
     response = collect_response_sync(sess, request_id)
 
     assert response is not None
@@ -142,17 +142,8 @@ def test_http_delete_with_body(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select
-            ((response).body)::jsonb body_json
-        from
-            net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).mappings().fetchone()
+    response = collect_response_sync(sess, request_id)
 
-    assert response["body_json"]["key"] == "val"
+    assert response is not None
+    assert response["body"] is not None
+    assert json.loads(response["body"])["key"] == "val"

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -31,22 +31,30 @@ def test_http_delete_collect_sync_success(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
+    # Collect the response, waiting as needed.
     response = sess.execute(
         text(
             """
-        select * from net._http_collect_response(:request_id, async:=false);
+        select
+            status,
+            message,
+            (response).status_code,
+            (response).headers,
+            (response).body
+        from net._http_collect_response(:request_id, async:=false);
     """
         ),
         {"request_id": request_id},
-        ).fetchone()
+    ).mappings().fetchone()
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
-    assert response[2] is not None
-    assert "X-Baz" in response[2]
-    assert "param-foo" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
+
+    # /delete echoes the request headers and query string back in the response body
+    assert response["body"] is not None
+    assert "X-Baz" in response["body"]
+    assert "param-foo" in response["body"]
 
 
 def test_http_delete_positional_args(sess):

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -68,7 +68,6 @@ def test_http_delete_positional_args(sess):
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
 
-
     (request_id,) = sess.execute(text(
         """
         select net.http_delete(
@@ -87,7 +86,6 @@ def test_http_delete_positional_args(sess):
     assert response is not None
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
-
 
     (request_id,) = sess.execute(text(
         """
@@ -108,7 +106,6 @@ def test_http_delete_positional_args(sess):
     assert response is not None
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
-
 
     (request_id,) = sess.execute(text(
         """
@@ -159,6 +156,6 @@ def test_http_delete_with_body(sess):
     """
         ),
         {"request_id": request_id},
-        ).mappings().fetchone()
+    ).mappings().fetchone()
 
     assert response["body_json"]["key"] == "val"

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -1,5 +1,4 @@
 import json
-
 from sqlalchemy import text
 from common import collect_response_sync, http_request
 
@@ -7,13 +6,13 @@ from common import collect_response_sync, http_request
 def test_http_delete_returns_id(sess):
     """Test net.http_delete returns an id"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/delete'
         );
     """
-    )).fetchone()
+    ))
 
     assert request_id == 1
 
@@ -21,7 +20,7 @@ def test_http_delete_returns_id(sess):
 def test_http_delete_collect_sync_success(sess):
     """Test net.http_delete works"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             url:='http://localhost:8080/delete'
@@ -50,7 +49,7 @@ def test_http_delete_positional_args(sess):
     """
 
     # Delete call with url only
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete'
@@ -65,7 +64,7 @@ def test_http_delete_positional_args(sess):
     assert response["message"] == "ok"
 
     # Delete call with url and params
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete',
@@ -81,7 +80,7 @@ def test_http_delete_positional_args(sess):
     assert response["message"] == "ok"
 
     # Delete call with url, params, and headers
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete',
@@ -98,7 +97,7 @@ def test_http_delete_positional_args(sess):
     assert response["message"] == "ok"
 
     # Delete call with url, params, headers, and timeout
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             'http://localhost:8080/delete',
@@ -119,7 +118,7 @@ def test_http_delete_positional_args(sess):
 def test_http_delete_with_body(sess):
     """Test delete with request body works"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_delete(
             url  :='http://localhost:8080/delete_w_body'

--- a/test/test_http_delete.py
+++ b/test/test_http_delete.py
@@ -1,4 +1,6 @@
 from sqlalchemy import text
+from common import collect_response_sync
+
 
 def test_http_delete_returns_id(sess):
     """net.http_delete returns a bigint id"""
@@ -31,27 +33,12 @@ def test_http_delete_collect_sync_success(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed.
-    response = sess.execute(
-        text(
-            """
-        select
-            status,
-            message,
-            (response).status_code,
-            (response).headers,
-            (response).body
-        from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).mappings().fetchone()
+    # Collect the response, waiting as needed
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
-
-    # /delete echoes the request headers and query string back in the response body
     assert response["body"] is not None
     assert "X-Baz" in response["body"]
     assert "param-foo" in response["body"]

--- a/test/test_http_errors.py
+++ b/test/test_http_errors.py
@@ -1,15 +1,15 @@
-import time
-
 import pytest
 from sqlalchemy import text
+from common import collect_response_sync, http_request, http_requests
 
 wrong_port = 6666
 
+
 def test_get_bad_url(sess):
-    """net.http_get returns a descriptive errors for bad urls"""
+    """Test net.http_get returns a descriptive errors for bad urls"""
 
     with pytest.raises(Exception) as execinfo:
-        res = sess.execute(text(
+        sess.execute(text(
             f"""
             select net.http_get('localhost:{wrong_port}');
         """
@@ -19,7 +19,7 @@ def test_get_bad_url(sess):
 
 
 def test_http_get_rejects_relative_url(sess):
-    """net.http_get with a correct error when given a relative url"""
+    """Test net.http_get with a correct error when given a relative url"""
 
     with pytest.raises(Exception) as execinfo:
         sess.execute(text(
@@ -32,10 +32,10 @@ def test_http_get_rejects_relative_url(sess):
 
 
 def test_bad_post(sess):
-    """net.http_post with an empty url + body returns an error"""
+    """Test net.http_post with an empty url + body returns an error"""
 
     with pytest.raises(Exception) as execinfo:
-        res = sess.execute(text(
+        sess.execute(text(
             """
             select net.http_post(null, '{"hello": "world"}');
         """
@@ -44,7 +44,7 @@ def test_bad_post(sess):
 
 
 def test_bad_get(sess):
-    """net.http_get with an empty url + body returns an error"""
+    """Test net.http_get with an empty url + body returns an error"""
 
     with pytest.raises(Exception) as execinfo:
         res = sess.execute(text(
@@ -56,10 +56,10 @@ def test_bad_get(sess):
 
 
 def test_bad_delete(sess):
-    """net.http_delete with an empty url + body returns an error"""
+    """Test net.http_delete with an empty url + body returns an error"""
 
     with pytest.raises(Exception) as execinfo:
-        res = sess.execute(text(
+        sess.execute(text(
             """
             select net.http_delete(null);
         """
@@ -68,7 +68,7 @@ def test_bad_delete(sess):
 
 
 def test_bad_utils(sess):
-    """util functions of pg_net return null"""
+    """Test util functions of pg_net return null"""
 
     res = sess.execute(text(
         """
@@ -88,29 +88,24 @@ def test_bad_utils(sess):
 
 
 def test_it_keeps_working_after_many_connection_refused(sess):
-    """the worker doesn't crash on many failed responses with connection refused"""
+    """
+    Test the worker doesn't crash on many failed responses
+    with connection refused
+    """
 
-    (request_id,) = sess.execute(text(
+    request_id = http_requests(sess, text(
         f"""
         select net.http_get('http://localhost:{wrong_port}') from generate_series(1,10) offset 9;
     """
-    )).fetchone()
-    sess.commit()
+    ))
 
-    # Collect the last response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "ERROR"
+    assert response["status"] == "ERROR"
 
-    (error_msg,count) = sess.execute(text(
-    """
+    (error_msg, count) = sess.execute(text(
+        """
         select error_msg, count(*) from net._http_response where status_code is null group by error_msg;
     """
     )).fetchone()
@@ -120,51 +115,38 @@ def test_it_keeps_working_after_many_connection_refused(sess):
     assert error_msg in expected
     assert count == 10
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200');
     """
-    )).fetchone()
+    ))
 
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
+    assert response["status_code"] == 200
 
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
-    assert response[2].startswith("(200")
 
 def test_it_keeps_working_after_server_returns_nothing(sess):
-    """the worker doesn't crash on many failed responses with server returned nothing"""
+    """
+    Test the worker doesn't crash on many failed responses
+    with server returned nothing
+    """
 
-    (request_id,) = sess.execute(text(
+    request_id = http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?disconnect=true') from generate_series(1,10) offset 9;
     """
-    )).fetchone()
-    sess.commit()
+    ))
 
-    # Collect the last response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "ERROR"
+    assert response["status"] == "ERROR"
 
-    (error_msg,count) = sess.execute(text(
-    """
+    (error_msg, count) = sess.execute(text(
+        """
         select error_msg, count(*) from net._http_response where status_code is null group by error_msg;
     """
     )).fetchone()
@@ -172,28 +154,18 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
     assert error_msg == "Server returned nothing (no headers, no data)"
     assert count == 10
 
-    (request_id,) = sess.execute(text(
+    request_id = http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10) offset 9;
     """
-    )).fetchone()
+    ))
 
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the last response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
-    assert response is not None
-    assert response[0] == "SUCCESS"
+    assert response["status"] == "SUCCESS"
 
-    (status_code,count) = sess.execute(text(
-    """
+    (status_code, count) = sess.execute(text(
+        """
         select status_code, count(*) from net._http_response where status_code = 200 group by status_code;
     """
     )).fetchone()

--- a/test/test_http_errors.py
+++ b/test/test_http_errors.py
@@ -1,6 +1,6 @@
 import pytest
 from sqlalchemy import text
-from common import collect_response_sync, http_request
+from common import collect_response_sync, http_request, http_requests
 
 wrong_port = 6666
 
@@ -93,7 +93,7 @@ def test_it_keeps_working_after_many_connection_refused(sess):
     with connection refused
     """
 
-    request_id = http_request(sess, text(
+    request_id = http_requests(sess, text(
         f"""
         select net.http_get('http://localhost:{wrong_port}') from generate_series(1,10) offset 9;
     """
@@ -134,7 +134,7 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
     with server returned nothing
     """
 
-    request_id = http_request(sess, text(
+    request_id = http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?disconnect=true') from generate_series(1,10) offset 9;
     """
@@ -154,7 +154,7 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
     assert error_msg == "Server returned nothing (no headers, no data)"
     assert count == 10
 
-    request_id = http_request(sess, text(
+    request_id = http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10) offset 9;
     """

--- a/test/test_http_errors.py
+++ b/test/test_http_errors.py
@@ -7,7 +7,7 @@ wrong_port = 6666
 
 
 def test_get_bad_url(sess):
-    """net.http_get returns a descriptive errors for bad urls"""
+    """Test net.http_get returns a descriptive errors for bad urls"""
 
     with pytest.raises(Exception) as execinfo:
         res = sess.execute(text(
@@ -20,7 +20,7 @@ def test_get_bad_url(sess):
 
 
 def test_http_get_rejects_relative_url(sess):
-    """net.http_get with a correct error when given a relative url"""
+    """Test net.http_get with a correct error when given a relative url"""
 
     with pytest.raises(Exception) as execinfo:
         sess.execute(text(
@@ -33,7 +33,7 @@ def test_http_get_rejects_relative_url(sess):
 
 
 def test_bad_post(sess):
-    """net.http_post with an empty url + body returns an error"""
+    """Test net.http_post with an empty url + body returns an error"""
 
     with pytest.raises(Exception) as execinfo:
         res = sess.execute(text(
@@ -45,7 +45,7 @@ def test_bad_post(sess):
 
 
 def test_bad_get(sess):
-    """net.http_get with an empty url + body returns an error"""
+    """Test net.http_get with an empty url + body returns an error"""
 
     with pytest.raises(Exception) as execinfo:
         res = sess.execute(text(
@@ -57,7 +57,7 @@ def test_bad_get(sess):
 
 
 def test_bad_delete(sess):
-    """net.http_delete with an empty url + body returns an error"""
+    """Test net.http_delete with an empty url + body returns an error"""
 
     with pytest.raises(Exception) as execinfo:
         res = sess.execute(text(
@@ -69,7 +69,7 @@ def test_bad_delete(sess):
 
 
 def test_bad_utils(sess):
-    """util functions of pg_net return null"""
+    """Test util functions of pg_net return null"""
 
     res = sess.execute(text(
         """
@@ -89,7 +89,10 @@ def test_bad_utils(sess):
 
 
 def test_it_keeps_working_after_many_connection_refused(sess):
-    """the worker doesn't crash on many failed responses with connection refused"""
+    """
+    Test the worker doesn't crash on many failed responses
+    with connection refused
+    """
 
     (request_id,) = sess.execute(text(
         f"""
@@ -144,7 +147,10 @@ def test_it_keeps_working_after_many_connection_refused(sess):
 
 
 def test_it_keeps_working_after_server_returns_nothing(sess):
-    """the worker doesn't crash on many failed responses with server returned nothing"""
+    """
+    Test the worker doesn't crash on many failed responses
+    with server returned nothing
+    """
 
     (request_id,) = sess.execute(text(
         """

--- a/test/test_http_errors.py
+++ b/test/test_http_errors.py
@@ -9,7 +9,7 @@ def test_get_bad_url(sess):
     """Test net.http_get returns a descriptive errors for bad urls"""
 
     with pytest.raises(Exception) as execinfo:
-        res = sess.execute(text(
+        sess.execute(text(
             f"""
             select net.http_get('localhost:{wrong_port}');
         """
@@ -35,7 +35,7 @@ def test_bad_post(sess):
     """Test net.http_post with an empty url + body returns an error"""
 
     with pytest.raises(Exception) as execinfo:
-        res = sess.execute(text(
+        sess.execute(text(
             """
             select net.http_post(null, '{"hello": "world"}');
         """
@@ -59,7 +59,7 @@ def test_bad_delete(sess):
     """Test net.http_delete with an empty url + body returns an error"""
 
     with pytest.raises(Exception) as execinfo:
-        res = sess.execute(text(
+        sess.execute(text(
             """
             select net.http_delete(null);
         """

--- a/test/test_http_errors.py
+++ b/test/test_http_errors.py
@@ -2,6 +2,7 @@ import time
 
 import pytest
 from sqlalchemy import text
+from common import collect_response_sync
 
 wrong_port = 6666
 
@@ -101,17 +102,10 @@ def test_it_keeps_working_after_many_connection_refused(sess):
     )).fetchone()
     sess.commit()
 
-    # Collect the last response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "ERROR"
+    assert response["status"] == "ERROR"
 
     (error_msg, count) = sess.execute(text(
         """
@@ -132,18 +126,11 @@ def test_it_keeps_working_after_many_connection_refused(sess):
 
     sess.commit()
 
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
-    assert response[2].startswith("(200")
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
+    assert response["status_code"] == 200
 
 
 def test_it_keeps_working_after_server_returns_nothing(sess):
@@ -159,17 +146,10 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
     )).fetchone()
     sess.commit()
 
-    # Collect the last response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "ERROR"
+    assert response["status"] == "ERROR"
 
     (error_msg, count) = sess.execute(text(
         """
@@ -188,17 +168,9 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
 
     sess.commit()
 
-    # Collect the last response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert response is not None
-    assert response[0] == "SUCCESS"
+    response = collect_response_sync(sess, request_id)
+
+    assert response["status"] == "SUCCESS"
 
     (status_code, count) = sess.execute(text(
         """

--- a/test/test_http_errors.py
+++ b/test/test_http_errors.py
@@ -93,7 +93,7 @@ def test_it_keeps_working_after_many_connection_refused(sess):
     with connection refused
     """
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         f"""
         select net.http_get('http://localhost:{wrong_port}') from generate_series(1,10) offset 9;
     """
@@ -115,7 +115,7 @@ def test_it_keeps_working_after_many_connection_refused(sess):
     assert error_msg in expected
     assert count == 10
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200');
     """
@@ -134,7 +134,7 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
     with server returned nothing
     """
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?disconnect=true') from generate_series(1,10) offset 9;
     """
@@ -154,7 +154,7 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
     assert error_msg == "Server returned nothing (no headers, no data)"
     assert count == 10
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10) offset 9;
     """

--- a/test/test_http_errors.py
+++ b/test/test_http_errors.py
@@ -5,6 +5,7 @@ from sqlalchemy import text
 
 wrong_port = 6666
 
+
 def test_get_bad_url(sess):
     """net.http_get returns a descriptive errors for bad urls"""
 
@@ -105,12 +106,12 @@ def test_it_keeps_working_after_many_connection_refused(sess):
     """
         ),
         {"request_id": request_id},
-        ).fetchone()
+    ).fetchone()
     assert response is not None
     assert response[0] == "ERROR"
 
-    (error_msg,count) = sess.execute(text(
-    """
+    (error_msg, count) = sess.execute(text(
+        """
         select error_msg, count(*) from net._http_response where status_code is null group by error_msg;
     """
     )).fetchone()
@@ -141,6 +142,7 @@ def test_it_keeps_working_after_many_connection_refused(sess):
     assert response[1] == "ok"
     assert response[2].startswith("(200")
 
+
 def test_it_keeps_working_after_server_returns_nothing(sess):
     """the worker doesn't crash on many failed responses with server returned nothing"""
 
@@ -159,12 +161,12 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
     """
         ),
         {"request_id": request_id},
-        ).fetchone()
+    ).fetchone()
     assert response is not None
     assert response[0] == "ERROR"
 
-    (error_msg,count) = sess.execute(text(
-    """
+    (error_msg, count) = sess.execute(text(
+        """
         select error_msg, count(*) from net._http_response where status_code is null group by error_msg;
     """
     )).fetchone()
@@ -188,12 +190,12 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
     """
         ),
         {"request_id": request_id},
-        ).fetchone()
+    ).fetchone()
     assert response is not None
     assert response[0] == "SUCCESS"
 
-    (status_code,count) = sess.execute(text(
-    """
+    (status_code, count) = sess.execute(text(
+        """
         select status_code, count(*) from net._http_response where status_code = 200 group by status_code;
     """
     )).fetchone()

--- a/test/test_http_errors.py
+++ b/test/test_http_errors.py
@@ -1,8 +1,6 @@
-import time
-
 import pytest
 from sqlalchemy import text
-from common import collect_response_sync
+from common import collect_response_sync, http_request
 
 wrong_port = 6666
 
@@ -95,12 +93,11 @@ def test_it_keeps_working_after_many_connection_refused(sess):
     with connection refused
     """
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         f"""
         select net.http_get('http://localhost:{wrong_port}') from generate_series(1,10) offset 9;
     """
-    )).fetchone()
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -118,13 +115,11 @@ def test_it_keeps_working_after_many_connection_refused(sess):
     assert error_msg in expected
     assert count == 10
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200');
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -139,12 +134,11 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
     with server returned nothing
     """
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?disconnect=true') from generate_series(1,10) offset 9;
     """
-    )).fetchone()
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -160,13 +154,11 @@ def test_it_keeps_working_after_server_returns_nothing(sess):
     assert error_msg == "Server returned nothing (no headers, no data)"
     assert count == 10
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10) offset 9;
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -1,27 +1,29 @@
 from sqlalchemy import text
 import time
 
+from common import collect_response_sync, http_request
+
 
 def test_http_get_returns_id(sess):
-    """net.http_get returns a bigint id"""
+    """Test net.http_get returns an id"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080');
     """
-    )).fetchone()
+    ))
 
     assert request_id == 1
 
 
 def test_http_get_works_with_ip(sess):
-    """net.http_get returns a bigint id when using an IP with port"""
+    """Test net.http_get returns an id when using an IP with port"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://127.0.0.1:8080');
     """
-    )).fetchone()
+    ))
 
     assert request_id == 1
 
@@ -29,60 +31,19 @@ def test_http_get_works_with_ip(sess):
 def test_http_get_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
-    # Create a request
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080');
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
-
-    # Collect the response, waiting as needed
-    response = sess.execute(text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
-    assert response[2] is not None
-    # psycopg2 does not deserialize nested composites
-    assert response[2].startswith("(200")
-
-
-# def test_http_get_collect_async_pending(sess):
-#     """Collect a response async before completed"""
-
-#     # Create a request
-#     (request_id,) = sess.execute(
-#         """
-#         select net.http_get('https://news.ycombinator.com');
-#     """
-#     ).fetchone()
-
-#     # Commit so background worker can start
-#     sess.commit()
-
-#     # Collect the response, waiting as needed
-#     response = sess.execute(
-#         text(
-#             """
-#         select * from net._http_collect_response(:request_id, async:=true);
-#     """
-#         ),
-#         {"request_id": request_id},
-#     ).fetchone()
-
-#     assert response is not None
-#     assert response[0] == "PENDING"
-#     assert "pending" in response[1]
-#     assert response[2] is None
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
+    assert response["body"] is not None
+    assert response["status_code"] == 200
 
 
 def test_http_collect_response_async_does_not_exist(sess):
@@ -99,114 +60,83 @@ def test_http_collect_response_async_does_not_exist(sess):
     assert "not found" in response[1]
     assert response[2] is None
 
+
 def test_http_get_responses_have_different_created_times(sess):
     """Ensure the rows in net._http_response have different created times"""
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/echo-method')
     """
     ))
-    sess.commit()
 
     time.sleep(1)
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/echo-method')
     """
     ))
-    sess.commit()
 
     time.sleep(1)
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/echo-method')
     """
     ))
-    sess.commit()
 
     time.sleep(1)
 
     count = sess.execute(text(
-            """
+        """
         select count(distinct created) from net._http_response;
     """
     )).scalar()
 
     assert count == 3
 
-def test_http_get_collect_with_redirect(sess):
-    """Follows a redirect and collects a response"""
 
-    # Create a request
-    (request_id,) = sess.execute(text(
+def test_http_get_collect_with_redirect(sess):
+    """Test pg_net follows a redirect and collects a response"""
+
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/redirect_me');
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
-
-    # Collect the response, waiting as needed
-    response = sess.execute(text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert "I got redirected" in response[2]
+    assert response["body"] == "I got redirected\n"
+
 
 def test_http_get_ipv6(sess):
-    """Can resolve an ipv6 only server"""
+    """Test pg_net can resolve an ipv6 only server"""
 
-    # Create a request
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8888/');
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
-
-    # Collect the response, waiting as needed
-    response = sess.execute(text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert "Hello ipv6 only" in response[2]
+    assert response["body"] == "Hello ipv6 only\n"
 
 
 def test_http_get_null_headers(sess):
-    """net.http_get can have null headers"""
+    """Test net.http_get can have null headers"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080', null::jsonb, null::jsonb, 100);
     """
-    )).fetchone()
+    ))
 
-    sess.commit()
-
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert "Hello world" in response[2]
+    assert response["body"] == "Hello world\n"

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -46,34 +46,6 @@ def test_http_get_collect_sync_success(sess):
     assert response["status_code"] == 200
 
 
-# def test_http_get_collect_async_pending(sess):
-#     """Collect a response async before completed"""
-
-#     (request_id,) = sess.execute(
-#         """
-#         select net.http_get('https://news.ycombinator.com');
-#     """
-#     ).fetchone()
-
-#     # Commit to wakeup background worker
-#     sess.commit()
-
-#     # Collect the response, waiting as needed
-#     response = sess.execute(
-#         text(
-#             """
-#         select * from net._http_collect_response(:request_id, async:=true);
-#     """
-#         ),
-#         {"request_id": request_id},
-#     ).fetchone()
-
-#     assert response is not None
-#     assert response[0] == "PENDING"
-#     assert "pending" in response[1]
-#     assert response[2] is None
-
-
 def test_http_collect_response_async_does_not_exist(sess):
     """Collect a non-existent response with async true"""
 

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -38,7 +38,7 @@ def test_http_get_collect_sync_success(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -60,7 +60,7 @@ def test_http_get_collect_sync_success(sess):
 #     """
 #     ).fetchone()
 
-#     # Commit so background worker can start
+#     # Commit to wakeup background worker
 #     sess.commit()
 
 #     # Collect the response, waiting as needed
@@ -143,7 +143,7 @@ def test_http_get_collect_with_redirect(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -162,7 +162,7 @@ def test_http_get_ipv6(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -41,10 +41,10 @@ def test_http_get_collect_sync_success(sess):
 
     # Collect the response, waiting as needed
     response = sess.execute(text(
-            """
+        """
         select * from net._http_collect_response(:request_id, async:=false);
     """
-        ),
+    ),
         {"request_id": request_id},
     ).fetchone()
 
@@ -99,6 +99,7 @@ def test_http_collect_response_async_does_not_exist(sess):
     assert "not found" in response[1]
     assert response[2] is None
 
+
 def test_http_get_responses_have_different_created_times(sess):
     """Ensure the rows in net._http_response have different created times"""
 
@@ -130,12 +131,13 @@ def test_http_get_responses_have_different_created_times(sess):
     time.sleep(1)
 
     count = sess.execute(text(
-            """
+        """
         select count(distinct created) from net._http_response;
     """
     )).scalar()
 
     assert count == 3
+
 
 def test_http_get_collect_with_redirect(sess):
     """Follows a redirect and collects a response"""
@@ -152,15 +154,16 @@ def test_http_get_collect_with_redirect(sess):
 
     # Collect the response, waiting as needed
     response = sess.execute(text(
-            """
+        """
         select * from net._http_collect_response(:request_id, async:=false);
     """
-        ),
+    ),
         {"request_id": request_id},
     ).fetchone()
 
     assert response is not None
     assert "I got redirected" in response[2]
+
 
 def test_http_get_ipv6(sess):
     """Can resolve an ipv6 only server"""
@@ -177,10 +180,10 @@ def test_http_get_ipv6(sess):
 
     # Collect the response, waiting as needed
     response = sess.execute(text(
-            """
+        """
         select * from net._http_collect_response(:request_id, async:=false);
     """
-        ),
+    ),
         {"request_id": request_id},
     ).fetchone()
 

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -1,6 +1,8 @@
 from sqlalchemy import text
 import time
 
+from common import collect_response_sync
+
 
 def test_http_get_returns_id(sess):
     """Test net.http_get returns a bigint id"""
@@ -39,21 +41,13 @@ def test_http_get_collect_sync_success(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(text(
-        """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-    ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
-    assert response[2] is not None
-    # psycopg2 does not deserialize nested composites
-    assert response[2].startswith("(200")
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
+    assert response["body"] is not None
+    assert response["status_code"] == 200
 
 
 # def test_http_get_collect_async_pending(sess):
@@ -152,17 +146,10 @@ def test_http_get_collect_with_redirect(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(text(
-        """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-    ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert "I got redirected" in response[2]
+    assert response["body"] == "I got redirected\n"
 
 
 def test_http_get_ipv6(sess):
@@ -178,17 +165,10 @@ def test_http_get_ipv6(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(text(
-        """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-    ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert "Hello ipv6 only" in response[2]
+    assert response["body"] == "Hello ipv6 only\n"
 
 
 def test_http_get_null_headers(sess):
@@ -202,14 +182,7 @@ def test_http_get_null_headers(sess):
 
     sess.commit()
 
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert "Hello world" in response[2]
+    assert response["body"] == "Hello world\n"

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -7,11 +7,11 @@ from common import collect_response_sync, http_request
 def test_http_get_returns_id(sess):
     """Test net.http_get returns an id"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080');
     """
-    )).fetchone()
+    ))
 
     assert request_id == 1
 
@@ -19,11 +19,11 @@ def test_http_get_returns_id(sess):
 def test_http_get_works_with_ip(sess):
     """Test net.http_get returns an id when using an IP with port"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://127.0.0.1:8080');
     """
-    )).fetchone()
+    ))
 
     assert request_id == 1
 
@@ -31,7 +31,7 @@ def test_http_get_works_with_ip(sess):
 def test_http_get_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080');
     """
@@ -100,7 +100,7 @@ def test_http_get_responses_have_different_created_times(sess):
 def test_http_get_collect_with_redirect(sess):
     """Test pg_net follows a redirect and collects a response"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/redirect_me');
     """
@@ -115,7 +115,7 @@ def test_http_get_collect_with_redirect(sess):
 def test_http_get_ipv6(sess):
     """Test pg_net can resolve an ipv6 only server"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8888/');
     """
@@ -130,7 +130,7 @@ def test_http_get_ipv6(sess):
 def test_http_get_null_headers(sess):
     """Test net.http_get can have null headers"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080', null::jsonb, null::jsonb, 100);
     """

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -3,7 +3,7 @@ import time
 
 
 def test_http_get_returns_id(sess):
-    """net.http_get returns a bigint id"""
+    """Test net.http_get returns a bigint id"""
 
     (request_id,) = sess.execute(text(
         """
@@ -15,7 +15,7 @@ def test_http_get_returns_id(sess):
 
 
 def test_http_get_works_with_ip(sess):
-    """net.http_get returns a bigint id when using an IP with port"""
+    """Test net.http_get returns a bigint id when using an IP with port"""
 
     (request_id,) = sess.execute(text(
         """
@@ -140,7 +140,7 @@ def test_http_get_responses_have_different_created_times(sess):
 
 
 def test_http_get_collect_with_redirect(sess):
-    """Follows a redirect and collects a response"""
+    """Test pg_net follows a redirect and collects a response"""
 
     # Create a request
     (request_id,) = sess.execute(text(
@@ -166,7 +166,7 @@ def test_http_get_collect_with_redirect(sess):
 
 
 def test_http_get_ipv6(sess):
-    """Can resolve an ipv6 only server"""
+    """Test pg_net can resolve an ipv6 only server"""
 
     # Create a request
     (request_id,) = sess.execute(text(
@@ -192,7 +192,7 @@ def test_http_get_ipv6(sess):
 
 
 def test_http_get_null_headers(sess):
-    """net.http_get can have null headers"""
+    """Test net.http_get can have null headers"""
 
     (request_id,) = sess.execute(text(
         """

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -1,7 +1,7 @@
 from sqlalchemy import text
 import time
 
-from common import collect_response_sync
+from common import collect_response_sync, http_request
 
 
 def test_http_get_returns_id(sess):
@@ -32,14 +32,11 @@ def test_http_get_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080');
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -97,30 +94,27 @@ def test_http_collect_response_async_does_not_exist(sess):
 def test_http_get_responses_have_different_created_times(sess):
     """Ensure the rows in net._http_response have different created times"""
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/echo-method')
     """
     ))
-    sess.commit()
 
     time.sleep(1)
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/echo-method')
     """
     ))
-    sess.commit()
 
     time.sleep(1)
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/echo-method')
     """
     ))
-    sess.commit()
 
     time.sleep(1)
 
@@ -137,14 +131,11 @@ def test_http_get_collect_with_redirect(sess):
     """Test pg_net follows a redirect and collects a response"""
 
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/redirect_me');
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -156,14 +147,11 @@ def test_http_get_ipv6(sess):
     """Test pg_net can resolve an ipv6 only server"""
 
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8888/');
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -174,13 +162,11 @@ def test_http_get_ipv6(sess):
 def test_http_get_null_headers(sess):
     """Test net.http_get can have null headers"""
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080', null::jsonb, null::jsonb, 100);
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -5,7 +5,7 @@ from common import collect_response_sync, http_request
 
 
 def test_http_get_returns_id(sess):
-    """Test net.http_get returns a bigint id"""
+    """Test net.http_get returns an id"""
 
     (request_id,) = sess.execute(text(
         """
@@ -17,7 +17,7 @@ def test_http_get_returns_id(sess):
 
 
 def test_http_get_works_with_ip(sess):
-    """Test net.http_get returns a bigint id when using an IP with port"""
+    """Test net.http_get returns an id when using an IP with port"""
 
     (request_id,) = sess.execute(text(
         """
@@ -31,7 +31,6 @@ def test_http_get_works_with_ip(sess):
 def test_http_get_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080');
@@ -50,7 +49,6 @@ def test_http_get_collect_sync_success(sess):
 # def test_http_get_collect_async_pending(sess):
 #     """Collect a response async before completed"""
 
-#     # Create a request
 #     (request_id,) = sess.execute(
 #         """
 #         select net.http_get('https://news.ycombinator.com');
@@ -130,7 +128,6 @@ def test_http_get_responses_have_different_created_times(sess):
 def test_http_get_collect_with_redirect(sess):
     """Test pg_net follows a redirect and collects a response"""
 
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/redirect_me');
@@ -146,7 +143,6 @@ def test_http_get_collect_with_redirect(sess):
 def test_http_get_ipv6(sess):
     """Test pg_net can resolve an ipv6 only server"""
 
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8888/');

--- a/test/test_http_headers.py
+++ b/test/test_http_headers.py
@@ -1,31 +1,19 @@
 from sqlalchemy import text
+from common import collect_response_sync, http_request
 
 
 def test_http_headers_set(sess):
     """Check that headers are being set"""
-    # Create a request
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/headers',
             headers:='{"pytest-header": "pytest-header", "accept": "application/json"}'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    print(response)
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "pytest-header" in response[2]
+    assert "pytest-header" in response["body"]

--- a/test/test_http_headers.py
+++ b/test/test_http_headers.py
@@ -4,7 +4,7 @@ from common import collect_response_sync, http_request
 
 def test_http_headers_set(sess):
     """Check that headers are being set"""
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/headers',

--- a/test/test_http_headers.py
+++ b/test/test_http_headers.py
@@ -1,4 +1,5 @@
 from sqlalchemy import text
+from common import collect_response_sync
 
 
 def test_http_headers_set(sess):
@@ -16,16 +17,7 @@ def test_http_headers_set(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    print(response)
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "pytest-header" in response[2]
+    assert "pytest-header" in response["body"]

--- a/test/test_http_headers.py
+++ b/test/test_http_headers.py
@@ -1,21 +1,18 @@
 from sqlalchemy import text
-from common import collect_response_sync
+from common import collect_response_sync, http_request
 
 
 def test_http_headers_set(sess):
     """Check that headers are being set"""
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/headers',
             headers:='{"pytest-header": "pytest-header", "accept": "application/json"}'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 

--- a/test/test_http_headers.py
+++ b/test/test_http_headers.py
@@ -14,7 +14,7 @@ def test_http_headers_set(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)

--- a/test/test_http_headers.py
+++ b/test/test_http_headers.py
@@ -4,7 +4,6 @@ from common import collect_response_sync, http_request
 
 def test_http_headers_set(sess):
     """Check that headers are being set"""
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_get(

--- a/test/test_http_malformed_headers.py
+++ b/test/test_http_malformed_headers.py
@@ -1,112 +1,83 @@
 from sqlalchemy import text
+from common import collect_response_sync, http_request
+
 
 def test_http_header_missing_value(sess):
     """Check that a `MissingValue: ` header is processed correctly"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=missing-value'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "MissingValue" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert "MissingValue" in response["headers"]
 
 
 def test_http_header_injection(sess):
-    """Check that a `HeaderInjection Injected-Header: This header contains an injection` header fails without crashing"""
+    """
+    Check that a `HeaderInjection Injected-Header: This header
+    contains an injection` header fails without crashing
+    """
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=header-injection'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
     assert response is not None
-    assert response[0] == "ERROR"
-    assert "Weird server reply" in response[1]
+    assert response["status"] == "ERROR"
+    assert "Weird server reply" in response["message"]
 
 
 def test_http_header_spaces(sess):
-    """Check that a `Spaces In Header Name: This header name contains spaces` header is processed correctly"""
+    """
+    Check that a `Spaces In Header Name: This header name contains spaces`
+    header is processed correctly
+    """
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=spaces-in-header-name'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "Spaces In Header Name" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert "Spaces In Header Name" in response["headers"]
 
 
 def test_http_header_non_printable_chars(sess):
-    """Check that a `NonPrintableChars: NonPrintableChars\\u0001\\u0002` header is processed correctly"""
+    """
+    Check that a `NonPrintableChars: NonPrintableChars\\u0001\\u0002`
+    header is processed correctly
+    """
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=non-printable-chars'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert r"NonPrintableChars\\u0001\\u0002" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert response["headers"]["NonPrintableChars"] == "NonPrintableChars\x01\x02"

--- a/test/test_http_malformed_headers.py
+++ b/test/test_http_malformed_headers.py
@@ -5,7 +5,7 @@ from common import collect_response_sync, http_request
 def test_http_header_missing_value(sess):
     """Check that a `MissingValue: ` header is processed correctly"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=missing-value'
@@ -26,7 +26,7 @@ def test_http_header_injection(sess):
     contains an injection` header fails without crashing
     """
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=header-injection'
@@ -47,7 +47,7 @@ def test_http_header_spaces(sess):
     header is processed correctly
     """
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=spaces-in-header-name'
@@ -68,7 +68,7 @@ def test_http_header_non_printable_chars(sess):
     header is processed correctly
     """
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=non-printable-chars'

--- a/test/test_http_malformed_headers.py
+++ b/test/test_http_malformed_headers.py
@@ -13,7 +13,7 @@ def test_http_header_missing_value(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -37,7 +37,7 @@ def test_http_header_injection(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -61,7 +61,7 @@ def test_http_header_spaces(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -85,7 +85,7 @@ def test_http_header_non_printable_chars(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)

--- a/test/test_http_malformed_headers.py
+++ b/test/test_http_malformed_headers.py
@@ -1,20 +1,17 @@
 from sqlalchemy import text
-from common import collect_response_sync
+from common import collect_response_sync, http_request
 
 
 def test_http_header_missing_value(sess):
     """Check that a `MissingValue: ` header is processed correctly"""
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=missing-value'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -29,16 +26,13 @@ def test_http_header_injection(sess):
     contains an injection` header fails without crashing
     """
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=header-injection'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -53,16 +47,13 @@ def test_http_header_spaces(sess):
     header is processed correctly
     """
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=spaces-in-header-name'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -77,16 +68,13 @@ def test_http_header_non_printable_chars(sess):
     header is processed correctly
     """
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/pathological?malformed-header=non-printable-chars'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 

--- a/test/test_http_malformed_headers.py
+++ b/test/test_http_malformed_headers.py
@@ -30,7 +30,10 @@ def test_http_header_missing_value(sess):
 
 
 def test_http_header_injection(sess):
-    """Check that a `HeaderInjection Injected-Header: This header contains an injection` header fails without crashing"""
+    """
+    Check that a `HeaderInjection Injected-Header: This header
+    contains an injection` header fails without crashing
+    """
 
     (request_id,) = sess.execute(text(
         """
@@ -58,7 +61,10 @@ def test_http_header_injection(sess):
 
 
 def test_http_header_spaces(sess):
-    """Check that a `Spaces In Header Name: This header name contains spaces` header is processed correctly"""
+    """
+    Check that a `Spaces In Header Name: This header name contains spaces`
+    header is processed correctly
+    """
 
     (request_id,) = sess.execute(text(
         """
@@ -86,7 +92,10 @@ def test_http_header_spaces(sess):
 
 
 def test_http_header_non_printable_chars(sess):
-    """Check that a `NonPrintableChars: NonPrintableChars\\u0001\\u0002` header is processed correctly"""
+    """
+    Check that a `NonPrintableChars: NonPrintableChars\\u0001\\u0002`
+    header is processed correctly
+    """
 
     (request_id,) = sess.execute(text(
         """

--- a/test/test_http_malformed_headers.py
+++ b/test/test_http_malformed_headers.py
@@ -1,4 +1,5 @@
 from sqlalchemy import text
+from common import collect_response_sync
 
 
 def test_http_header_missing_value(sess):
@@ -15,18 +16,11 @@ def test_http_header_missing_value(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "MissingValue" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert "MissingValue" in response["headers"]
 
 
 def test_http_header_injection(sess):
@@ -46,18 +40,11 @@ def test_http_header_injection(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "ERROR"
-    assert "Weird server reply" in response[1]
+    assert response["status"] == "ERROR"
+    assert "Weird server reply" in response["message"]
 
 
 def test_http_header_spaces(sess):
@@ -77,18 +64,11 @@ def test_http_header_spaces(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "Spaces In Header Name" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert "Spaces In Header Name" in response["headers"]
 
 
 def test_http_header_non_printable_chars(sess):
@@ -108,15 +88,8 @@ def test_http_header_non_printable_chars(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert r"NonPrintableChars\\u0001\\u0002" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert response["headers"]["NonPrintableChars"] == "NonPrintableChars\x01\x02"

--- a/test/test_http_malformed_headers.py
+++ b/test/test_http_malformed_headers.py
@@ -1,5 +1,6 @@
 from sqlalchemy import text
 
+
 def test_http_header_missing_value(sess):
     """Check that a `MissingValue: ` header is processed correctly"""
 

--- a/test/test_http_params.py
+++ b/test/test_http_params.py
@@ -1,63 +1,38 @@
 from sqlalchemy import text
+from common import collect_response_sync, http_request
 
 
 def test_http_get_url_params_set(sess):
-    """Check that params are being set on GET
-    """
-    # Create a request
-    (request_id,) = sess.execute(text(
+    """Check that params are being set on GET"""
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/anything',
             params:='{"hello": "world"}'::jsonb
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    print(response)
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "?hello=world" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert "?hello=world" in response["body"]
 
 
 def test_http_post_url_params_set(sess):
-    """Check that params are being set on POST
-    """
-    # Create a request
-    (request_id,) = sess.execute(text(
+    """Check that params are being set on POST"""
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/anything',
             params:='{"hello": "world"}'::jsonb
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    print(response)
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "?hello=world" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert "?hello=world" in response["body"]

--- a/test/test_http_params.py
+++ b/test/test_http_params.py
@@ -2,8 +2,7 @@ from sqlalchemy import text
 
 
 def test_http_get_url_params_set(sess):
-    """Check that params are being set on GET
-    """
+    """Check that params are being set on GET"""
     # Create a request
     (request_id,) = sess.execute(text(
         """
@@ -33,8 +32,7 @@ def test_http_get_url_params_set(sess):
 
 
 def test_http_post_url_params_set(sess):
-    """Check that params are being set on POST
-    """
+    """Check that params are being set on POST"""
     # Create a request
     (request_id,) = sess.execute(text(
         """

--- a/test/test_http_params.py
+++ b/test/test_http_params.py
@@ -4,7 +4,6 @@ from common import collect_response_sync, http_request
 
 def test_http_get_url_params_set(sess):
     """Check that params are being set on GET"""
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_get(
@@ -23,7 +22,6 @@ def test_http_get_url_params_set(sess):
 
 def test_http_post_url_params_set(sess):
     """Check that params are being set on POST"""
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_post(

--- a/test/test_http_params.py
+++ b/test/test_http_params.py
@@ -4,7 +4,7 @@ from common import collect_response_sync, http_request
 
 def test_http_get_url_params_set(sess):
     """Check that params are being set on GET"""
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/anything',
@@ -22,7 +22,7 @@ def test_http_get_url_params_set(sess):
 
 def test_http_post_url_params_set(sess):
     """Check that params are being set on POST"""
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/anything',

--- a/test/test_http_params.py
+++ b/test/test_http_params.py
@@ -1,4 +1,5 @@
 from sqlalchemy import text
+from common import collect_response_sync
 
 
 def test_http_get_url_params_set(sess):
@@ -16,19 +17,11 @@ def test_http_get_url_params_set(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    print(response)
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "?hello=world" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert "?hello=world" in response["body"]
 
 
 def test_http_post_url_params_set(sess):
@@ -46,16 +39,8 @@ def test_http_post_url_params_set(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    print(response)
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "?hello=world" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert "?hello=world" in response["body"]

--- a/test/test_http_params.py
+++ b/test/test_http_params.py
@@ -14,7 +14,7 @@ def test_http_get_url_params_set(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -36,7 +36,7 @@ def test_http_post_url_params_set(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)

--- a/test/test_http_params.py
+++ b/test/test_http_params.py
@@ -1,21 +1,18 @@
 from sqlalchemy import text
-from common import collect_response_sync
+from common import collect_response_sync, http_request
 
 
 def test_http_get_url_params_set(sess):
     """Check that params are being set on GET"""
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(
             url:='http://localhost:8080/anything',
             params:='{"hello": "world"}'::jsonb
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -27,17 +24,14 @@ def test_http_get_url_params_set(sess):
 def test_http_post_url_params_set(sess):
     """Check that params are being set on POST"""
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/anything',
             params:='{"hello": "world"}'::jsonb
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -114,20 +114,12 @@ def test_http_post_collect_non_empty_body(sess):
     assert response["body"] is not None
     assert json.loads(response["body"])["hello"] == "world"
 
-    # Make sure response is json
-    (response_json,) = sess.execute(
-        text(
-            """
-        select
-            ((x.response).body)::jsonb body_json
-        from
-            net._http_collect_response(:request_id, async:=false) x;
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    # Assert that response is json
+    response = collect_response_sync(sess, request_id)
 
-    assert response_json["hello"] == "world"
+    assert response is not None
+    assert response["body"] is not None
+    assert json.loads(response["body"])["hello"] == "world"
 
 
 def test_http_post_wrong_header_exception(sess):
@@ -193,15 +185,7 @@ def test_http_post_empty_body(sess):
 
     sess.commit()
 
-    (body) = sess.execute(
-        text(
-            """
-        select
-            (x.response).body as body
-        from net._http_collect_response(:request_id, async:=false) x;
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
-    assert 'POST' in str(body)
+    assert response is not None
+    assert response["body"] == "POST\n"

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -1,5 +1,4 @@
 import json
-
 from sqlalchemy import text
 from common import collect_response_sync, http_request
 
@@ -7,14 +6,14 @@ from common import collect_response_sync, http_request
 def test_http_post_returns_id(sess):
     """Test net.http_post returns an id"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
             body:='{}'::jsonb
         );
     """
-    )).fetchone()
+    ))
 
     assert request_id == 1
 
@@ -22,14 +21,14 @@ def test_http_post_returns_id(sess):
 def test_http_post_special_chars_body(sess):
     """Test net.http_post returns an id"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
             body:=json_build_object('foo', 'ba"r')::jsonb
         );
     """
-    )).fetchone()
+    ))
 
     assert request_id == 1
 
@@ -37,7 +36,7 @@ def test_http_post_special_chars_body(sess):
 def test_http_post_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/post'
@@ -56,7 +55,7 @@ def test_http_post_collect_sync_success(sess):
 def test_http_post_collect_non_empty_body(sess):
     """Collect a response async before completed"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
@@ -127,7 +126,7 @@ def test_http_post_no_content_type_coerce(sess):
 def test_http_post_empty_body(sess):
     """Test net.http_post can post a null body"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/echo-method',

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -5,7 +5,7 @@ from common import collect_response_sync, http_request
 
 
 def test_http_post_returns_id(sess):
-    """Test net.http_post returns a bigint id"""
+    """Test net.http_post returns an id"""
 
     (request_id,) = sess.execute(text(
         """
@@ -20,7 +20,7 @@ def test_http_post_returns_id(sess):
 
 
 def test_http_post_special_chars_body(sess):
-    """Test net.http_post returns a bigint id"""
+    """Test net.http_post returns an id"""
 
     (request_id,) = sess.execute(text(
         """
@@ -37,7 +37,6 @@ def test_http_post_special_chars_body(sess):
 def test_http_post_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_post(
@@ -57,7 +56,6 @@ def test_http_post_collect_sync_success(sess):
 # def test_http_post_collect_async_pending(sess):
 #     """Collect a response async before completed"""
 
-#     # Create a request
 #     (request_id,) = sess.execute(
 #         """
 #         select net.http_post(
@@ -89,7 +87,6 @@ def test_http_post_collect_sync_success(sess):
 def test_http_post_collect_non_empty_body(sess):
     """Collect a response async before completed"""
 
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_post(
@@ -106,13 +103,7 @@ def test_http_post_collect_non_empty_body(sess):
     assert response["status"] == "SUCCESS"
     assert response["message"] == "ok"
     assert response["body"] is not None
-    assert json.loads(response["body"])["hello"] == "world"
-
     # Assert that response is json
-    response = collect_response_sync(sess, request_id)
-
-    assert response is not None
-    assert response["body"] is not None
     assert json.loads(response["body"])["hello"] == "world"
 
 
@@ -140,7 +131,6 @@ def test_http_post_wrong_header_exception(sess):
 def test_http_post_no_content_type_coerce(sess):
     """Confirm that a missing content type coerces to application/json"""
 
-    # Create a request
     request_id, = sess.execute(text(
         """
         select net.http_post(

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -46,7 +46,7 @@ def test_http_post_collect_sync_success(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -70,7 +70,7 @@ def test_http_post_collect_sync_success(sess):
 #     """
 #     ).fetchone()
 
-#     # Commit so background worker can start
+#     # Commit to wakeup background worker
 #     sess.commit()
 
 #     # Collect the response, waiting as needed
@@ -103,7 +103,7 @@ def test_http_post_collect_non_empty_body(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -176,7 +176,6 @@ def test_http_post_no_content_type_coerce(sess):
     """
     )).fetchone()
 
-
     headers, = sess.execute(text(
         """
         select

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -1,7 +1,7 @@
 import json
 
 from sqlalchemy import text
-from common import collect_response_sync
+from common import collect_response_sync, http_request
 
 
 def test_http_post_returns_id(sess):
@@ -38,16 +38,13 @@ def test_http_post_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/post'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -93,7 +90,7 @@ def test_http_post_collect_non_empty_body(sess):
     """Collect a response async before completed"""
 
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
@@ -101,10 +98,7 @@ def test_http_post_collect_non_empty_body(sess):
             headers:='{"Content-Type": "application/json", "accept": "application/json"}'::jsonb
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -174,16 +168,14 @@ def test_http_post_no_content_type_coerce(sess):
 def test_http_post_empty_body(sess):
     """Test net.http_post can post a null body"""
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/echo-method',
             body:=null
         );
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -2,7 +2,7 @@ from sqlalchemy import text
 
 
 def test_http_post_returns_id(sess):
-    """net.http_post returns a bigint id"""
+    """Test net.http_post returns a bigint id"""
 
     (request_id,) = sess.execute(text(
         """
@@ -17,7 +17,7 @@ def test_http_post_returns_id(sess):
 
 
 def test_http_post_special_chars_body(sess):
-    """net.http_post returns a bigint id"""
+    """Test net.http_post returns a bigint id"""
 
     (request_id,) = sess.execute(text(
         """
@@ -192,7 +192,7 @@ def test_http_post_no_content_type_coerce(sess):
 
 
 def test_http_post_empty_body(sess):
-    """net.http_post can post a null body"""
+    """Test net.http_post can post a null body"""
 
     (request_id,) = sess.execute(text(
         """

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -53,37 +53,6 @@ def test_http_post_collect_sync_success(sess):
     assert response["body"] is not None
 
 
-# def test_http_post_collect_async_pending(sess):
-#     """Collect a response async before completed"""
-
-#     (request_id,) = sess.execute(
-#         """
-#         select net.http_post(
-#             url:='http://localhost:8080/post',
-#             body:='{}'::jsonb
-#         );
-#     """
-#     ).fetchone()
-
-#     # Commit to wakeup background worker
-#     sess.commit()
-
-#     # Collect the response, waiting as needed
-#     response = sess.execute(
-#         text(
-#             """
-#         select * from net._http_collect_response(:request_id, async:=true);
-#     """
-#         ),
-#         {"request_id": request_id},
-#     ).fetchone()
-
-#     assert response is not None
-#     assert response[0] == "PENDING"
-#     assert "pending" in response[1]
-#     assert response[2] is None
-
-
 def test_http_post_collect_non_empty_body(sess):
     """Collect a response async before completed"""
 

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -1,32 +1,34 @@
+import json
 from sqlalchemy import text
+from common import collect_response_sync, http_request
 
 
 def test_http_post_returns_id(sess):
-    """net.http_post returns a bigint id"""
+    """Test net.http_post returns an id"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
             body:='{}'::jsonb
         );
     """
-    )).fetchone()
+    ))
 
     assert request_id == 1
 
 
 def test_http_post_special_chars_body(sess):
-    """net.http_post returns a bigint id"""
+    """Test net.http_post returns an id"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
             body:=json_build_object('foo', 'ba"r')::jsonb
         );
     """
-    )).fetchone()
+    ))
 
     assert request_id == 1
 
@@ -34,71 +36,26 @@ def test_http_post_special_chars_body(sess):
 def test_http_post_collect_sync_success(sess):
     """Collect a response, waiting if it has not completed yet"""
 
-    # Create a request
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/post'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
-
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
-    assert response[2] is not None
-
-
-# def test_http_post_collect_async_pending(sess):
-#     """Collect a response async before completed"""
-
-#     # Create a request
-#     (request_id,) = sess.execute(
-#         """
-#         select net.http_post(
-#             url:='http://localhost:8080/post',
-#             body:='{}'::jsonb
-#         );
-#     """
-#     ).fetchone()
-
-#     # Commit so background worker can start
-#     sess.commit()
-
-#     # Collect the response, waiting as needed
-#     response = sess.execute(
-#         text(
-#             """
-#         select * from net._http_collect_response(:request_id, async:=true);
-#     """
-#         ),
-#         {"request_id": request_id},
-#     ).fetchone()
-
-#     assert response is not None
-#     assert response[0] == "PENDING"
-#     assert "pending" in response[1]
-#     assert response[2] is None
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
+    assert response["body"] is not None
 
 
 def test_http_post_collect_non_empty_body(sess):
     """Collect a response async before completed"""
 
-    # Create a request
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/post',
@@ -106,40 +63,16 @@ def test_http_post_collect_non_empty_body(sess):
             headers:='{"Content-Type": "application/json", "accept": "application/json"}'::jsonb
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "ok" in response[1]
-    assert "hello" in response[2]
-    assert "world" in response[2]
-
-    # Make sure response is json
-    (response_json,) = sess.execute(
-        text(
-            """
-        select
-            ((x.response).body)::jsonb body_json
-        from
-            net._http_collect_response(:request_id, async:=false) x;
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-
-    assert response_json["hello"] == "world"
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
+    assert response["body"] is not None
+    # Assert that response is json
+    assert json.loads(response["body"])["hello"] == "world"
 
 
 def test_http_post_wrong_header_exception(sess):
@@ -166,7 +99,6 @@ def test_http_post_wrong_header_exception(sess):
 def test_http_post_no_content_type_coerce(sess):
     """Confirm that a missing content type coerces to application/json"""
 
-    # Create a request
     request_id, = sess.execute(text(
         """
         select net.http_post(
@@ -175,7 +107,6 @@ def test_http_post_no_content_type_coerce(sess):
         );
     """
     )).fetchone()
-
 
     headers, = sess.execute(text(
         """
@@ -193,28 +124,18 @@ def test_http_post_no_content_type_coerce(sess):
 
 
 def test_http_post_empty_body(sess):
-    """net.http_post can post a null body"""
+    """Test net.http_post can post a null body"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_post(
             url:='http://localhost:8080/echo-method',
             body:=null
         );
     """
-    )).fetchone()
+    ))
 
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    (body) = sess.execute(
-        text(
-            """
-        select
-            (x.response).body as body
-        from net._http_collect_response(:request_id, async:=false) x;
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-
-    assert 'POST' in str(body)
+    assert response is not None
+    assert response["body"] == "POST\n"

--- a/test/test_http_post_collect.py
+++ b/test/test_http_post_collect.py
@@ -1,4 +1,7 @@
+import json
+
 from sqlalchemy import text
+from common import collect_response_sync
 
 
 def test_http_post_returns_id(sess):
@@ -46,20 +49,12 @@ def test_http_post_collect_sync_success(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
 
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert response[1] == "ok"
-    assert response[2] is not None
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
+    assert response["body"] is not None
 
 
 # def test_http_post_collect_async_pending(sess):
@@ -111,20 +106,13 @@ def test_http_post_collect_non_empty_body(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Collect the response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "SUCCESS"
-    assert "ok" in response[1]
-    assert "hello" in response[2]
-    assert "world" in response[2]
+    assert response["status"] == "SUCCESS"
+    assert response["message"] == "ok"
+    assert response["body"] is not None
+    assert json.loads(response["body"])["hello"] == "world"
 
     # Make sure response is json
     (response_json,) = sess.execute(

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -1,187 +1,127 @@
 import time
-
-import pytest
 from sqlalchemy import text
+from common import collect_response_sync, http_request, http_requests, restart_worker
+from common import wait_for_response_count, wakeup_worker
+
 
 def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
-    """Check that http responses will be deleted when they reach their ttl, not immediately but when the worker wakes again"""
+    """
+    Check that http responses will be deleted when they reach their ttl,
+    not immediately but when the worker wakes again
+    """
 
-    autocommit_sess.execute(text("alter system set pg_net.ttl to '1 second'"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    try:
+        autocommit_sess.execute(
+            text("alter system set pg_net.ttl to '1 second'"))
+        restart_worker(autocommit_sess)
 
-    # Create a request
-    (request_id,) = sess.execute(text(
+        request_id = http_request(sess, text(
+            """
+            select net.http_get(
+                'http://localhost:8080/anything'
+            );
         """
-        select net.http_get(
-            'http://localhost:8080/anything'
-        );
-    """
-    )).fetchone()
+        ))
 
-    # Commit so background worker can start
-    sess.commit()
+        response = collect_response_sync(sess, request_id)
 
-    # Confirm that the request was retrievable
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert response[0] == "SUCCESS"
+        assert response is not None
+        assert response["status"] == "SUCCESS"
 
-    # Sleep until after request should have been deleted
-    time.sleep(1.1)
+        # Sleep a little more than ttl so that the request expires
+        time.sleep(1.1)
 
-    # Wake the worker manually, under normal operation this will happen when new requests are received
-    sess.execute(text("select net.wake()"))
+        wakeup_worker(sess)
 
-    sess.commit() # commit so worker  wakes
+        # Check that the worker deleted the expired response
+        wait_for_response_count(autocommit_sess, 0)
 
-    time.sleep(0.1) # wait for deletion
-
-    # Ensure the response is now empty
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response where id = :request_id;
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert count == 0
-
-    autocommit_sess.execute(text("alter system reset pg_net.ttl"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.ttl"))
+        restart_worker(autocommit_sess)
 
 
 def test_http_responses_will_complete_deletion(sess, autocommit_sess):
-    """Check that http responses will keep being deleted until completion despite no new requests coming"""
+    """
+    Check that http responses will keep being deleted
+    until completion despite no new requests coming
+    """
 
-    (request_id,) = sess.execute(text(
+    request_id = http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,4) offset 3;
     """
-    )).fetchone()
+    ))
 
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the last response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
     assert response is not None
-    assert response[0] == "SUCCESS"
+    assert response["status"] == "SUCCESS"
 
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response
-    """
-        )
-    ).fetchone()
-    assert count == 4
+    wait_for_response_count(autocommit_sess, 4)
 
-    autocommit_sess.execute(text("alter system set pg_net.ttl to '1 second';"))
-    autocommit_sess.execute(text("alter system set pg_net.batch_size to 2;"))
-    autocommit_sess.execute(text("select pg_reload_conf();"))
+    try:
+        autocommit_sess.execute(
+            text("alter system set pg_net.ttl to '1 second';"))
+        autocommit_sess.execute(
+            text("alter system set pg_net.batch_size to 2;"))
+        autocommit_sess.execute(text("select pg_reload_conf();"))
 
-    # wait for ttl
-    time.sleep(1)
+        # Wait for ttl so that when we wakeup the worker it has
+        # some expired responses to delete
+        time.sleep(1)
 
-    # Wake the worker manually, under normal operation this will happen when new requests are received
-    sess.execute(text("select net.wake()"))
-    sess.commit() # commit so worker  wakes
+        wakeup_worker(sess)
 
-    time.sleep(0.1)
+        # In one inner loop, the worker will delete batch size
+        # worth of responses
+        wait_for_response_count(autocommit_sess, 2)
 
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response
-    """
-        )
-    ).fetchone()
-    assert count == 2
+        # But it will keep going as long as it had deleted
+        # some responses. So after a wait of 1 second it
+        # will delete another batch before going back to sleep
+        wait_for_response_count(autocommit_sess, 0)
 
-    # wait for another batch
-    time.sleep(1.1)
-
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response
-    """
-        )
-    ).fetchone()
-    assert count == 0
-
-    autocommit_sess.execute(text("alter system reset pg_net.ttl"))
-    autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-    autocommit_sess.execute(text("select pg_reload_conf();"))
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.ttl"))
+        autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
+        autocommit_sess.execute(text("select pg_reload_conf();"))
 
 
 def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
-    """Check that http responses will keep being despite no new requests coming" and despite restart"""
+    """
+    Check that http responses will keep being deleted despite no
+    new requests coming and despite worker restart
+    """
 
-    (request_id,) = sess.execute(text(
+    request_id = http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,4) offset 3;
     """
-    )).fetchone()
+    ))
 
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Collect the last response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-        ).fetchone()
     assert response is not None
-    assert response[0] == "SUCCESS"
+    assert response["status"] == "SUCCESS"
 
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response
-    """
-        )
-    ).fetchone()
-    assert count == 4
+    wait_for_response_count(autocommit_sess, 4)
 
-    # restart
-    autocommit_sess.execute(text("alter system set pg_net.ttl to '1 second';"))
-    autocommit_sess.execute(text("alter system set pg_net.batch_size to 2;"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    try:
+        # Restart the worker
+        autocommit_sess.execute(
+            text("alter system set pg_net.ttl to '1 second';"))
+        autocommit_sess.execute(
+            text("alter system set pg_net.batch_size to 2;"))
+        restart_worker(autocommit_sess)
 
-    # wait for ttl
-    time.sleep(1.1)
+        # Wait for ttl so that the requests expire
+        time.sleep(1.1)
 
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response
-    """
-        )
-    ).fetchone()
-    assert count == 0
+        wait_for_response_count(autocommit_sess, 0)
 
-    # reset
-    autocommit_sess.execute(text("alter system reset pg_net.ttl"))
-    autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    finally:
+        # reset
+        autocommit_sess.execute(text("alter system reset pg_net.ttl"))
+        autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
+        restart_worker(autocommit_sess)

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -1,6 +1,7 @@
 import time
 from sqlalchemy import text
-from common import collect_response_sync, http_request, restart_worker, wait_for_response_count, wakeup_worker
+from common import collect_response_sync, http_request, restart_worker
+from common import wait_for_response_count, wakeup_worker
 
 
 def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
@@ -14,7 +15,7 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
             text("alter system set pg_net.ttl to '1 second'"))
         restart_worker(autocommit_sess)
 
-        (request_id,) = http_request(sess, text(
+        request_id = http_request(sess, text(
             """
             select net.http_get(
                 'http://localhost:8080/anything'
@@ -46,7 +47,7 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
     until completion despite no new requests coming
     """
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,4) offset 3;
     """
@@ -93,7 +94,7 @@ def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
     new requests coming and despite worker restart
     """
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,4) offset 3;
     """

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -9,47 +9,50 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
     not immediately but when the worker wakes again
     """
 
-    autocommit_sess.execute(text("alter system set pg_net.ttl to '1 second'"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    try:
+        autocommit_sess.execute(
+            text("alter system set pg_net.ttl to '1 second'"))
+        autocommit_sess.execute(text("select net.worker_restart()"))
+        autocommit_sess.execute(text("select net.wait_until_running()"))
 
-    (request_id,) = http_request(sess, text(
-        """
-        select net.http_get(
-            'http://localhost:8080/anything'
-        );
-    """
-    ))
-
-    response = collect_response_sync(sess, request_id)
-
-    assert response is not None
-    assert response["status"] == "SUCCESS"
-
-    # Sleep until after request should have been deleted
-    time.sleep(1.1)
-
-    # Wake the worker manually, under normal operation this will happen when new requests are received
-    sess.execute(text("select net.wake()"))
-
-    sess.commit()  # commit so worker  wakes
-
-    time.sleep(0.1)  # wait for deletion
-
-    # Ensure the response is now empty
-    (count,) = sess.execute(
-        text(
+        (request_id,) = http_request(sess, text(
             """
-        select count(*) from net._http_response where id = :request_id;
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert count == 0
+            select net.http_get(
+                'http://localhost:8080/anything'
+            );
+        """
+        ))
 
-    autocommit_sess.execute(text("alter system reset pg_net.ttl"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+        response = collect_response_sync(sess, request_id)
+
+        assert response is not None
+        assert response["status"] == "SUCCESS"
+
+        # Sleep until after request should have been deleted
+        time.sleep(1.1)
+
+        # Wake the worker manually, under normal operation this will happen when new requests are received
+        sess.execute(text("select net.wake()"))
+
+        sess.commit()  # commit so worker  wakes
+
+        time.sleep(0.1)  # wait for deletion
+
+        # Ensure the response is now empty
+        (count,) = sess.execute(
+            text(
+                """
+            select count(*) from net._http_response where id = :request_id;
+        """
+            ),
+            {"request_id": request_id},
+        ).fetchone()
+        assert count == 0
+
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.ttl"))
+        autocommit_sess.execute(text("select net.worker_restart()"))
+        autocommit_sess.execute(text("select net.wait_until_running()"))
 
 
 def test_http_responses_will_complete_deletion(sess, autocommit_sess):
@@ -78,43 +81,47 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
     ).fetchone()
     assert count == 4
 
-    autocommit_sess.execute(text("alter system set pg_net.ttl to '1 second';"))
-    autocommit_sess.execute(text("alter system set pg_net.batch_size to 2;"))
-    autocommit_sess.execute(text("select pg_reload_conf();"))
+    try:
+        autocommit_sess.execute(
+            text("alter system set pg_net.ttl to '1 second';"))
+        autocommit_sess.execute(
+            text("alter system set pg_net.batch_size to 2;"))
+        autocommit_sess.execute(text("select pg_reload_conf();"))
 
-    # wait for ttl
-    time.sleep(1)
+        # wait for ttl
+        time.sleep(1)
 
-    # Wake the worker manually, under normal operation this will happen when new requests are received
-    sess.execute(text("select net.wake()"))
-    sess.commit()  # commit so worker  wakes
+        # Wake the worker manually, under normal operation this will happen when new requests are received
+        sess.execute(text("select net.wake()"))
+        sess.commit()  # commit so worker  wakes
 
-    time.sleep(0.1)
+        time.sleep(0.1)
 
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response
-    """
-        )
-    ).fetchone()
-    assert count == 2
+        (count,) = sess.execute(
+            text(
+                """
+            select count(*) from net._http_response
+        """
+            )
+        ).fetchone()
+        assert count == 2
 
-    # wait for another batch
-    time.sleep(1.1)
+        # wait for another batch
+        time.sleep(1.1)
 
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response
-    """
-        )
-    ).fetchone()
-    assert count == 0
+        (count,) = sess.execute(
+            text(
+                """
+            select count(*) from net._http_response
+        """
+            )
+        ).fetchone()
+        assert count == 0
 
-    autocommit_sess.execute(text("alter system reset pg_net.ttl"))
-    autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-    autocommit_sess.execute(text("select pg_reload_conf();"))
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.ttl"))
+        autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
+        autocommit_sess.execute(text("select pg_reload_conf();"))
 
 
 def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
@@ -143,26 +150,30 @@ def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
     ).fetchone()
     assert count == 4
 
-    # restart
-    autocommit_sess.execute(text("alter system set pg_net.ttl to '1 second';"))
-    autocommit_sess.execute(text("alter system set pg_net.batch_size to 2;"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    try:
+        # restart
+        autocommit_sess.execute(
+            text("alter system set pg_net.ttl to '1 second';"))
+        autocommit_sess.execute(
+            text("alter system set pg_net.batch_size to 2;"))
+        autocommit_sess.execute(text("select net.worker_restart()"))
+        autocommit_sess.execute(text("select net.wait_until_running()"))
 
-    # wait for ttl
-    time.sleep(1.1)
+        # wait for ttl
+        time.sleep(1.1)
 
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response
-    """
-        )
-    ).fetchone()
-    assert count == 0
+        (count,) = sess.execute(
+            text(
+                """
+            select count(*) from net._http_response
+        """
+            )
+        ).fetchone()
+        assert count == 0
 
-    # reset
-    autocommit_sess.execute(text("alter system reset pg_net.ttl"))
-    autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    finally:
+        # reset
+        autocommit_sess.execute(text("alter system reset pg_net.ttl"))
+        autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
+        autocommit_sess.execute(text("select net.worker_restart()"))
+        autocommit_sess.execute(text("select net.wait_until_running()"))

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -24,7 +24,7 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -5,7 +5,10 @@ from sqlalchemy import text
 
 
 def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
-    """Check that http responses will be deleted when they reach their ttl, not immediately but when the worker wakes again"""
+    """
+    Check that http responses will be deleted when they reach their ttl,
+    not immediately but when the worker wakes again
+    """
 
     autocommit_sess.execute(text("alter system set pg_net.ttl to '1 second'"))
     autocommit_sess.execute(text("select net.worker_restart()"))
@@ -61,7 +64,10 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
 
 
 def test_http_responses_will_complete_deletion(sess, autocommit_sess):
-    """Check that http responses will keep being deleted until completion despite no new requests coming"""
+    """
+    Check that http responses will keep being deleted
+    until completion despite no new requests coming
+    """
 
     (request_id,) = sess.execute(text(
         """
@@ -132,7 +138,10 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
 
 
 def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
-    """Check that http responses will keep being despite no new requests coming" and despite restart"""
+    """
+    Check that http responses will keep being despite no
+    new requests coming" and despite restart
+    """
 
     (request_id,) = sess.execute(text(
         """

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -13,7 +13,6 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
     autocommit_sess.execute(text("select net.worker_restart()"))
     autocommit_sess.execute(text("select net.wait_until_running()"))
 
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_get(

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -1,6 +1,6 @@
 import time
 from sqlalchemy import text
-from common import collect_response_sync, http_request, wait_until
+from common import collect_response_sync, http_request, wait_for_response_count, wait_until
 
 
 def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
@@ -37,22 +37,7 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
         sess.commit()  # commit so worker  wakes
 
         # Ensure the response is now empty
-        def get_count():
-            (count,) = sess.execute(
-                text(
-                    """
-                select count(*) from net._http_response where id = :request_id;
-            """
-                ),
-                {"request_id": request_id},
-            ).fetchone()
-            return count
-
-        wait_until(
-            get_count,
-            lambda count: count == 0,
-            description="response to be deleted after ttl",
-        )
+        wait_for_response_count(autocommit_sess, 0)
 
     finally:
         autocommit_sess.execute(text("alter system reset pg_net.ttl"))

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -1,8 +1,6 @@
 import time
-
-import pytest
 from sqlalchemy import text
-from common import collect_response_sync
+from common import collect_response_sync, http_request
 
 
 def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
@@ -16,16 +14,13 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
     autocommit_sess.execute(text("select net.wait_until_running()"))
 
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(
             'http://localhost:8080/anything'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -64,13 +59,11 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
     until completion despite no new requests coming
     """
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,4) offset 3;
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 
@@ -131,13 +124,11 @@ def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
     new requests coming" and despite restart
     """
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,4) offset 3;
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -1,6 +1,6 @@
 import time
 from sqlalchemy import text
-from common import collect_response_sync, http_request, wait_for_response_count, wait_until, wakeup_worker
+from common import collect_response_sync, http_request, restart_worker, wait_for_response_count, wakeup_worker
 
 
 def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
@@ -12,8 +12,7 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
     try:
         autocommit_sess.execute(
             text("alter system set pg_net.ttl to '1 second'"))
-        autocommit_sess.execute(text("select net.worker_restart()"))
-        autocommit_sess.execute(text("select net.wait_until_running()"))
+        restart_worker(autocommit_sess)
 
         (request_id,) = http_request(sess, text(
             """
@@ -38,8 +37,7 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
 
     finally:
         autocommit_sess.execute(text("alter system reset pg_net.ttl"))
-        autocommit_sess.execute(text("select net.worker_restart()"))
-        autocommit_sess.execute(text("select net.wait_until_running()"))
+        restart_worker(autocommit_sess)
 
 
 def test_http_responses_will_complete_deletion(sess, autocommit_sess):
@@ -114,8 +112,7 @@ def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
             text("alter system set pg_net.ttl to '1 second';"))
         autocommit_sess.execute(
             text("alter system set pg_net.batch_size to 2;"))
-        autocommit_sess.execute(text("select net.worker_restart()"))
-        autocommit_sess.execute(text("select net.wait_until_running()"))
+        restart_worker(autocommit_sess)
 
         # Wait for ttl so that the requests expire
         time.sleep(1.1)
@@ -126,5 +123,4 @@ def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
         # reset
         autocommit_sess.execute(text("alter system reset pg_net.ttl"))
         autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-        autocommit_sess.execute(text("select net.worker_restart()"))
-        autocommit_sess.execute(text("select net.wait_until_running()"))
+        restart_worker(autocommit_sess)

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -3,6 +3,7 @@ import time
 import pytest
 from sqlalchemy import text
 
+
 def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
     """Check that http responses will be deleted when they reach their ttl, not immediately but when the worker wakes again"""
 
@@ -39,9 +40,9 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
     # Wake the worker manually, under normal operation this will happen when new requests are received
     sess.execute(text("select net.wake()"))
 
-    sess.commit() # commit so worker  wakes
+    sess.commit()  # commit so worker  wakes
 
-    time.sleep(0.1) # wait for deletion
+    time.sleep(0.1)  # wait for deletion
 
     # Ensure the response is now empty
     (count,) = sess.execute(
@@ -78,7 +79,7 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
     """
         ),
         {"request_id": request_id},
-        ).fetchone()
+    ).fetchone()
     assert response is not None
     assert response[0] == "SUCCESS"
 
@@ -100,7 +101,7 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
 
     # Wake the worker manually, under normal operation this will happen when new requests are received
     sess.execute(text("select net.wake()"))
-    sess.commit() # commit so worker  wakes
+    sess.commit()  # commit so worker  wakes
 
     time.sleep(0.1)
 
@@ -149,7 +150,7 @@ def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
     """
         ),
         {"request_id": request_id},
-        ).fetchone()
+    ).fetchone()
     assert response is not None
     assert response[0] == "SUCCESS"
 

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -1,6 +1,6 @@
 import time
 from sqlalchemy import text
-from common import collect_response_sync, http_request, wait_for_response_count, wait_until
+from common import collect_response_sync, http_request, wait_for_response_count, wait_until, wakeup_worker
 
 
 def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
@@ -28,15 +28,12 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
         assert response is not None
         assert response["status"] == "SUCCESS"
 
-        # Sleep until after request should have been deleted
+        # Sleep a little more than ttl so that the request expires
         time.sleep(1.1)
 
-        # Wake the worker manually, under normal operation this will happen when new requests are received
-        sess.execute(text("select net.wake()"))
+        wakeup_worker(sess)
 
-        sess.commit()  # commit so worker  wakes
-
-        # Ensure the response is now empty
+        # Check that the worker deleted the expired response
         wait_for_response_count(autocommit_sess, 0)
 
     finally:
@@ -62,14 +59,7 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
     assert response is not None
     assert response["status"] == "SUCCESS"
 
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response
-    """
-        )
-    ).fetchone()
-    assert count == 4
+    wait_for_response_count(autocommit_sess, 4)
 
     try:
         autocommit_sess.execute(
@@ -78,35 +68,20 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
             text("alter system set pg_net.batch_size to 2;"))
         autocommit_sess.execute(text("select pg_reload_conf();"))
 
-        # wait for ttl
+        # Wait for ttl so that when we wakeup the worker it has
+        # some expired responses to delete
         time.sleep(1)
 
-        # Wake the worker manually, under normal operation this will happen when new requests are received
-        sess.execute(text("select net.wake()"))
-        sess.commit()  # commit so worker  wakes
+        wakeup_worker(sess)
 
-        time.sleep(0.1)
+        # In one inner loop, the worker will delete batch size
+        # worth of responses
+        wait_for_response_count(autocommit_sess, 2)
 
-        (count,) = sess.execute(
-            text(
-                """
-            select count(*) from net._http_response
-        """
-            )
-        ).fetchone()
-        assert count == 2
-
-        # wait for another batch
-        time.sleep(1.1)
-
-        (count,) = sess.execute(
-            text(
-                """
-            select count(*) from net._http_response
-        """
-            )
-        ).fetchone()
-        assert count == 0
+        # But it will keep going as long as it had deleted
+        # some responses. So after a wait of 1 second it
+        # will delete another batch before going back to sleep
+        wait_for_response_count(autocommit_sess, 0)
 
     finally:
         autocommit_sess.execute(text("alter system reset pg_net.ttl"))
@@ -116,8 +91,8 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
 
 def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
     """
-    Check that http responses will keep being despite no
-    new requests coming" and despite restart
+    Check that http responses will keep being deleted despite no
+    new requests coming and despite worker restart
     """
 
     (request_id,) = http_request(sess, text(
@@ -131,17 +106,10 @@ def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
     assert response is not None
     assert response["status"] == "SUCCESS"
 
-    (count,) = sess.execute(
-        text(
-            """
-        select count(*) from net._http_response
-    """
-        )
-    ).fetchone()
-    assert count == 4
+    wait_for_response_count(autocommit_sess, 4)
 
     try:
-        # restart
+        # Restart the worker
         autocommit_sess.execute(
             text("alter system set pg_net.ttl to '1 second';"))
         autocommit_sess.execute(
@@ -149,17 +117,10 @@ def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
         autocommit_sess.execute(text("select net.worker_restart()"))
         autocommit_sess.execute(text("select net.wait_until_running()"))
 
-        # wait for ttl
+        # Wait for ttl so that the requests expire
         time.sleep(1.1)
 
-        (count,) = sess.execute(
-            text(
-                """
-            select count(*) from net._http_response
-        """
-            )
-        ).fetchone()
-        assert count == 0
+        wait_for_response_count(autocommit_sess, 0)
 
     finally:
         # reset

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -1,6 +1,6 @@
 import time
 from sqlalchemy import text
-from common import collect_response_sync, http_request
+from common import collect_response_sync, http_request, wait_until
 
 
 def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
@@ -36,18 +36,23 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
 
         sess.commit()  # commit so worker  wakes
 
-        time.sleep(0.1)  # wait for deletion
-
         # Ensure the response is now empty
-        (count,) = sess.execute(
-            text(
-                """
-            select count(*) from net._http_response where id = :request_id;
-        """
-            ),
-            {"request_id": request_id},
-        ).fetchone()
-        assert count == 0
+        def get_count():
+            (count,) = sess.execute(
+                text(
+                    """
+                select count(*) from net._http_response where id = :request_id;
+            """
+                ),
+                {"request_id": request_id},
+            ).fetchone()
+            return count
+
+        wait_until(
+            get_count,
+            lambda count: count == 0,
+            description="response to be deleted after ttl",
+        )
 
     finally:
         autocommit_sess.execute(text("alter system reset pg_net.ttl"))

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -1,6 +1,6 @@
 import time
 from sqlalchemy import text
-from common import collect_response_sync, http_request, restart_worker
+from common import collect_response_sync, http_request, http_requests, restart_worker
 from common import wait_for_response_count, wakeup_worker
 
 
@@ -47,7 +47,7 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
     until completion despite no new requests coming
     """
 
-    request_id = http_request(sess, text(
+    request_id = http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,4) offset 3;
     """
@@ -94,7 +94,7 @@ def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
     new requests coming and despite worker restart
     """
 
-    request_id = http_request(sess, text(
+    request_id = http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,4) offset 3;
     """

--- a/test/test_http_requests_deleted_after_ttl.py
+++ b/test/test_http_requests_deleted_after_ttl.py
@@ -2,6 +2,7 @@ import time
 
 import pytest
 from sqlalchemy import text
+from common import collect_response_sync
 
 
 def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
@@ -26,16 +27,10 @@ def test_http_responses_deleted_after_ttl(sess, autocommit_sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Confirm that the request was retrievable
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert response[0] == "SUCCESS"
+    response = collect_response_sync(sess, request_id)
+
+    assert response is not None
+    assert response["status"] == "SUCCESS"
 
     # Sleep until after request should have been deleted
     time.sleep(1.1)
@@ -77,17 +72,10 @@ def test_http_responses_will_complete_deletion(sess, autocommit_sess):
 
     sess.commit()
 
-    # Collect the last response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "SUCCESS"
+    assert response["status"] == "SUCCESS"
 
     (count,) = sess.execute(
         text(
@@ -151,17 +139,10 @@ def test_http_responses_will_delete_despite_restart(sess, autocommit_sess):
 
     sess.commit()
 
-    # Collect the last response, waiting as needed
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
+    response = collect_response_sync(sess, request_id)
+
     assert response is not None
-    assert response[0] == "SUCCESS"
+    assert response["status"] == "SUCCESS"
 
     (count,) = sess.execute(
         text(

--- a/test/test_http_timeout.py
+++ b/test/test_http_timeout.py
@@ -1,24 +1,22 @@
 import time
-
-import pytest
 import re
 from sqlalchemy import text
+from common import http_request
+
 
 def test_http_get_timeout_reached(sess):
-    """net.http_get with timeout errs on a slow reply"""
+    """Test net.http_get with timeout errs on a slow reply"""
 
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(url := 'http://localhost:8080/pathological?status=200&delay=6');
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     # wait for timeout
     time.sleep(7)
 
-    (content_type, content, response,timed_out) = sess.execute(
+    (content_type, content, response, timed_out) = sess.execute(
         text(
             """
         select content_type, content, error_msg, timed_out from net._http_response where id = :request_id;
@@ -34,7 +32,7 @@ def test_http_get_timeout_reached(sess):
 
 
 def test_http_detailed_timeout(sess):
-    """the timeout shows a detailed error msg"""
+    """Test the timeout shows a detailed error msg"""
 
     pattern = r"""
         Total\stime:\s*                     # Match 'Total time:' with optional spaces
@@ -58,18 +56,16 @@ def test_http_detailed_timeout(sess):
     # select net.http_get(url := 'http://localhost:8080/pathological', timeout_milliseconds := 1000);
 
     # Timeout at the HTTP step
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(url := 'http://localhost:8080/pathological?delay=1', timeout_milliseconds := 1000)
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     # wait for timeout
     time.sleep(2.1)
 
-    (content_type, content, response,timed_out) = sess.execute(
+    (content_type, content, response, timed_out) = sess.execute(
         text(
             """
         select content_type, content, error_msg, timed_out from net._http_response where id = :request_id;
@@ -80,10 +76,10 @@ def test_http_detailed_timeout(sess):
 
     match = regex.search(response)
 
-    total_time   = float(match.group('A'))
-    dns_time     = float(match.group('B'))
+    total_time = float(match.group('A'))
+    dns_time = float(match.group('B'))
     tcp_ssl_time = float(match.group('C'))
-    http_time    = float(match.group('D'))
+    http_time = float(match.group('D'))
 
     assert content_type == None
     assert content == None
@@ -93,16 +89,18 @@ def test_http_detailed_timeout(sess):
     assert tcp_ssl_time > 0
     assert http_time > 0
 
-def test_http_get_succeed_with_gt_timeout(sess):
-    """net.http_get with timeout succeeds when the timeout is greater than the slow reply response time"""
 
-    (request_id,) = sess.execute(text(
+def test_http_get_succeed_with_gt_timeout(sess):
+    """
+    Test net.http_get with timeout succeeds when the timeout
+    is greater than the slow reply response time
+    """
+
+    request_id = http_request(sess, text(
         """
         select net.http_get(url := 'http://localhost:8080?status=200&delay=3', timeout_milliseconds := 3500);
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     time.sleep(4.5)
 
@@ -117,11 +115,15 @@ def test_http_get_succeed_with_gt_timeout(sess):
 
     assert status_code == 200
 
+
 def test_many_slow_mixed_with_fast(sess):
-    """many fast responses finish despite being mixed with slow responses, the fast responses will wait the timeout duration"""
+    """
+    Test many fast responses finish despite being mixed with slow responses,
+    the fast responses will wait the timeout duration
+    """
 
     sess.execute(text(
-    """
+        """
       select
         net.http_get(url := 'http://localhost:8080/pathological?status=200')
       , net.http_get(url := 'http://localhost:8080/pathological?status=200&delay=2', timeout_milliseconds := 1000)
@@ -137,7 +139,7 @@ def test_many_slow_mixed_with_fast(sess):
     time.sleep(3)
 
     (request_successes, request_timeouts) = sess.execute(text(
-    """
+        """
       select
         count(*) filter (where error_msg is null and status_code = 200) as request_successes,
         count(*) filter (where error_msg is not null and error_msg like 'Timeout of 1000 ms reached%') as request_timeouts

--- a/test/test_http_timeout.py
+++ b/test/test_http_timeout.py
@@ -6,7 +6,7 @@ from sqlalchemy import text
 
 
 def test_http_get_timeout_reached(sess):
-    """net.http_get with timeout errs on a slow reply"""
+    """Test net.http_get with timeout errs on a slow reply"""
 
     (request_id,) = sess.execute(text(
         """
@@ -35,7 +35,7 @@ def test_http_get_timeout_reached(sess):
 
 
 def test_http_detailed_timeout(sess):
-    """the timeout shows a detailed error msg"""
+    """Test the timeout shows a detailed error msg"""
 
     pattern = r"""
         Total\stime:\s*                     # Match 'Total time:' with optional spaces
@@ -96,7 +96,10 @@ def test_http_detailed_timeout(sess):
 
 
 def test_http_get_succeed_with_gt_timeout(sess):
-    """net.http_get with timeout succeeds when the timeout is greater than the slow reply response time"""
+    """
+    Test net.http_get with timeout succeeds when the timeout
+    is greater than the slow reply response time
+    """
 
     (request_id,) = sess.execute(text(
         """
@@ -121,7 +124,10 @@ def test_http_get_succeed_with_gt_timeout(sess):
 
 
 def test_many_slow_mixed_with_fast(sess):
-    """many fast responses finish despite being mixed with slow responses, the fast responses will wait the timeout duration"""
+    """
+    Test many fast responses finish despite being mixed with slow responses,
+    the fast responses will wait the timeout duration
+    """
 
     sess.execute(text(
         """

--- a/test/test_http_timeout.py
+++ b/test/test_http_timeout.py
@@ -1,20 +1,18 @@
 import time
 
-import pytest
 import re
 from sqlalchemy import text
+from common import http_request
 
 
 def test_http_get_timeout_reached(sess):
     """Test net.http_get with timeout errs on a slow reply"""
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(url := 'http://localhost:8080/pathological?status=200&delay=6');
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     # wait for timeout
     time.sleep(7)
@@ -59,13 +57,11 @@ def test_http_detailed_timeout(sess):
     # select net.http_get(url := 'http://localhost:8080/pathological', timeout_milliseconds := 1000);
 
     # Timeout at the HTTP step
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(url := 'http://localhost:8080/pathological?delay=1', timeout_milliseconds := 1000)
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     # wait for timeout
     time.sleep(2.1)
@@ -101,13 +97,11 @@ def test_http_get_succeed_with_gt_timeout(sess):
     is greater than the slow reply response time
     """
 
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(url := 'http://localhost:8080?status=200&delay=3', timeout_milliseconds := 3500);
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     time.sleep(4.5)
 

--- a/test/test_http_timeout.py
+++ b/test/test_http_timeout.py
@@ -1,5 +1,4 @@
 import time
-
 import re
 from sqlalchemy import text
 from common import http_request
@@ -8,7 +7,7 @@ from common import http_request
 def test_http_get_timeout_reached(sess):
     """Test net.http_get with timeout errs on a slow reply"""
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(url := 'http://localhost:8080/pathological?status=200&delay=6');
     """
@@ -57,7 +56,7 @@ def test_http_detailed_timeout(sess):
     # select net.http_get(url := 'http://localhost:8080/pathological', timeout_milliseconds := 1000);
 
     # Timeout at the HTTP step
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(url := 'http://localhost:8080/pathological?delay=1', timeout_milliseconds := 1000)
     """
@@ -97,7 +96,7 @@ def test_http_get_succeed_with_gt_timeout(sess):
     is greater than the slow reply response time
     """
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(url := 'http://localhost:8080?status=200&delay=3', timeout_milliseconds := 3500);
     """

--- a/test/test_http_timeout.py
+++ b/test/test_http_timeout.py
@@ -4,6 +4,7 @@ import pytest
 import re
 from sqlalchemy import text
 
+
 def test_http_get_timeout_reached(sess):
     """net.http_get with timeout errs on a slow reply"""
 
@@ -18,7 +19,7 @@ def test_http_get_timeout_reached(sess):
     # wait for timeout
     time.sleep(7)
 
-    (content_type, content, response,timed_out) = sess.execute(
+    (content_type, content, response, timed_out) = sess.execute(
         text(
             """
         select content_type, content, error_msg, timed_out from net._http_response where id = :request_id;
@@ -69,7 +70,7 @@ def test_http_detailed_timeout(sess):
     # wait for timeout
     time.sleep(2.1)
 
-    (content_type, content, response,timed_out) = sess.execute(
+    (content_type, content, response, timed_out) = sess.execute(
         text(
             """
         select content_type, content, error_msg, timed_out from net._http_response where id = :request_id;
@@ -80,10 +81,10 @@ def test_http_detailed_timeout(sess):
 
     match = regex.search(response)
 
-    total_time   = float(match.group('A'))
-    dns_time     = float(match.group('B'))
+    total_time = float(match.group('A'))
+    dns_time = float(match.group('B'))
     tcp_ssl_time = float(match.group('C'))
-    http_time    = float(match.group('D'))
+    http_time = float(match.group('D'))
 
     assert content_type == None
     assert content == None
@@ -92,6 +93,7 @@ def test_http_detailed_timeout(sess):
     assert dns_time > 0
     assert tcp_ssl_time > 0
     assert http_time > 0
+
 
 def test_http_get_succeed_with_gt_timeout(sess):
     """net.http_get with timeout succeeds when the timeout is greater than the slow reply response time"""
@@ -117,11 +119,12 @@ def test_http_get_succeed_with_gt_timeout(sess):
 
     assert status_code == 200
 
+
 def test_many_slow_mixed_with_fast(sess):
     """many fast responses finish despite being mixed with slow responses, the fast responses will wait the timeout duration"""
 
     sess.execute(text(
-    """
+        """
       select
         net.http_get(url := 'http://localhost:8080/pathological?status=200')
       , net.http_get(url := 'http://localhost:8080/pathological?status=200&delay=2', timeout_milliseconds := 1000)
@@ -137,7 +140,7 @@ def test_many_slow_mixed_with_fast(sess):
     time.sleep(3)
 
     (request_successes, request_timeouts) = sess.execute(text(
-    """
+        """
       select
         count(*) filter (where error_msg is null and status_code = 200) as request_successes,
         count(*) filter (where error_msg is not null and error_msg like 'Timeout of 1000 ms reached%') as request_timeouts

--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -1,5 +1,6 @@
-import pytest
 from sqlalchemy import text
+from common import collect_response_sync, http_request
+
 
 def test_net_on_postgres_role(sess):
     """Check that the postgres role can use the net schema by default"""
@@ -7,28 +8,18 @@ def test_net_on_postgres_role(sess):
     role = sess.execute(text("select current_user;")).fetchone()
     assert role[0] == "postgres"
 
-    # Create a request
-    (request_id,) = sess.execute(text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             'http://localhost:8080/anything'
         );
     """
-    )).fetchone()
+    ))
 
-    # Commit so background worker can start
-    sess.commit()
+    response = collect_response_sync(sess, request_id)
 
-    # Confirm that the request was retrievable
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert response[0] == "SUCCESS"
+    assert response is not None
+    assert response["status"] == "SUCCESS"
 
 
 def test_net_on_pre_existing_role(sess):
@@ -37,7 +28,6 @@ def test_net_on_pre_existing_role(sess):
     role = sess.execute(text("select current_user;")).fetchone()
     assert role[0] == "postgres"
 
-    # Create a request
     (request_id, current_user) = sess.execute(text(
         """
         set local role to pre_existing;
@@ -49,21 +39,16 @@ def test_net_on_pre_existing_role(sess):
     assert request_id == 1
     assert current_user == 'pre_existing'
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     # Confirm that the request was retrievable
-    response = sess.execute(
-        text(
-            """
-        set local role to pre_existing;
-        select *, current_user from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert response[0] == "SUCCESS"
-    assert response[3] == 'pre_existing' # current-user
+    sess.execute(text("set local role to pre_existing;"))
+    response = collect_response_sync(sess, request_id)
+    current_user = sess.execute(text("select current_user;")).scalar()
+    assert response["status"] == "SUCCESS"
+    assert current_user == 'pre_existing'
+
 
 def test_net_on_new_role(sess):
     """Check that a newly created role can use the net schema"""
@@ -75,7 +60,6 @@ def test_net_on_new_role(sess):
         create role another;
     """))
 
-    # Create a request
     (request_id, current_user) = sess.execute(text(
         """
         set local role to another;
@@ -87,23 +71,17 @@ def test_net_on_new_role(sess):
     assert request_id == 1
     assert current_user == 'another'
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     # Confirm that the request was retrievable
-    response = sess.execute(
-        text(
-            """
-        set local role to another;
-        select *, current_user from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert response[0] == "SUCCESS"
-    assert response[3] == 'another' # current-user
+    sess.execute(text("set local role to another;"))
+    response = collect_response_sync(sess, request_id)
+    current_user = sess.execute(text("select current_user;")).scalar()
+    assert response["status"] == "SUCCESS"
+    assert current_user == 'another'
 
-    ## can use the net.worker_restart function
+    # can use the net.worker_restart function
     (res, current_user) = sess.execute(
         text(
             """

--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -17,7 +17,7 @@ def test_net_on_postgres_role(sess):
     """
     )).fetchone()
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     response = collect_response_sync(sess, request_id)
@@ -44,7 +44,7 @@ def test_net_on_pre_existing_role(sess):
     assert request_id == 1
     assert current_user == 'pre_existing'
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     # Confirm that the request was retrievable
@@ -77,7 +77,7 @@ def test_net_on_new_role(sess):
     assert request_id == 1
     assert current_user == 'another'
 
-    # Commit so background worker can start
+    # Commit to wakeup background worker
     sess.commit()
 
     # Confirm that the request was retrievable

--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -8,7 +8,6 @@ def test_net_on_postgres_role(sess):
     role = sess.execute(text("select current_user;")).fetchone()
     assert role[0] == "postgres"
 
-    # Create a request
     (request_id,) = http_request(sess, text(
         """
         select net.http_get(
@@ -29,7 +28,6 @@ def test_net_on_pre_existing_role(sess):
     role = sess.execute(text("select current_user;")).fetchone()
     assert role[0] == "postgres"
 
-    # Create a request
     (request_id, current_user) = sess.execute(text(
         """
         set local role to pre_existing;
@@ -62,7 +60,6 @@ def test_net_on_new_role(sess):
         create role another;
     """))
 
-    # Create a request
     (request_id, current_user) = sess.execute(text(
         """
         set local role to another;

--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -48,17 +48,11 @@ def test_net_on_pre_existing_role(sess):
     sess.commit()
 
     # Confirm that the request was retrievable
-    response = sess.execute(
-        text(
-            """
-        set local role to pre_existing;
-        select *, current_user from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert response[0] == "SUCCESS"
-    assert response[3] == 'pre_existing'  # current-user
+    sess.execute(text("set local role to pre_existing;"))
+    response = collect_response_sync(sess, request_id)
+    current_user = sess.execute(text("select current_user;")).scalar()
+    assert response["status"] == "SUCCESS"
+    assert current_user == 'pre_existing'
 
 
 def test_net_on_new_role(sess):
@@ -87,17 +81,11 @@ def test_net_on_new_role(sess):
     sess.commit()
 
     # Confirm that the request was retrievable
-    response = sess.execute(
-        text(
-            """
-        set local role to another;
-        select *, current_user from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert response[0] == "SUCCESS"
-    assert response[3] == 'another'  # current-user
+    sess.execute(text("set local role to another;"))
+    response = collect_response_sync(sess, request_id)
+    current_user = sess.execute(text("select current_user;")).scalar()
+    assert response["status"] == "SUCCESS"
+    assert current_user == 'another'
 
     # can use the net.worker_restart function
     (res, current_user) = sess.execute(

--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -8,7 +8,7 @@ def test_net_on_postgres_role(sess):
     role = sess.execute(text("select current_user;")).fetchone()
     assert role[0] == "postgres"
 
-    (request_id,) = http_request(sess, text(
+    request_id = http_request(sess, text(
         """
         select net.http_get(
             'http://localhost:8080/anything'

--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -1,6 +1,7 @@
 import pytest
 from sqlalchemy import text
 
+
 def test_net_on_postgres_role(sess):
     """Check that the postgres role can use the net schema by default"""
 
@@ -63,7 +64,8 @@ def test_net_on_pre_existing_role(sess):
         {"request_id": request_id},
     ).fetchone()
     assert response[0] == "SUCCESS"
-    assert response[3] == 'pre_existing' # current-user
+    assert response[3] == 'pre_existing'  # current-user
+
 
 def test_net_on_new_role(sess):
     """Check that a newly created role can use the net schema"""
@@ -101,9 +103,9 @@ def test_net_on_new_role(sess):
         {"request_id": request_id},
     ).fetchone()
     assert response[0] == "SUCCESS"
-    assert response[3] == 'another' # current-user
+    assert response[3] == 'another'  # current-user
 
-    ## can use the net.worker_restart function
+    # can use the net.worker_restart function
     (res, current_user) = sess.execute(
         text(
             """

--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -1,5 +1,5 @@
-import pytest
 from sqlalchemy import text
+from common import collect_response_sync
 
 
 def test_net_on_postgres_role(sess):
@@ -20,16 +20,10 @@ def test_net_on_postgres_role(sess):
     # Commit so background worker can start
     sess.commit()
 
-    # Confirm that the request was retrievable
-    response = sess.execute(
-        text(
-            """
-        select * from net._http_collect_response(:request_id, async:=false);
-    """
-        ),
-        {"request_id": request_id},
-    ).fetchone()
-    assert response[0] == "SUCCESS"
+    response = collect_response_sync(sess, request_id)
+
+    assert response is not None
+    assert response["status"] == "SUCCESS"
 
 
 def test_net_on_pre_existing_role(sess):

--- a/test/test_privileges.py
+++ b/test/test_privileges.py
@@ -1,5 +1,5 @@
 from sqlalchemy import text
-from common import collect_response_sync
+from common import collect_response_sync, http_request
 
 
 def test_net_on_postgres_role(sess):
@@ -9,16 +9,13 @@ def test_net_on_postgres_role(sess):
     assert role[0] == "postgres"
 
     # Create a request
-    (request_id,) = sess.execute(text(
+    (request_id,) = http_request(sess, text(
         """
         select net.http_get(
             'http://localhost:8080/anything'
         );
     """
-    )).fetchone()
-
-    # Commit to wakeup background worker
-    sess.commit()
+    ))
 
     response = collect_response_sync(sess, request_id)
 

--- a/test/test_stat_statements.py
+++ b/test/test_stat_statements.py
@@ -1,11 +1,10 @@
 import time
-
 import pytest
 from sqlalchemy import text
+from common import http_requests
 
-def test_query_stat_statements(sess):
-    """Check that the background worker doesn't execute queries when no new requests arrive"""
 
+def skip_test_if_pg_is_old(sess):
     (pg_version,) = sess.execute(text(
         """
         select current_setting('server_version_num');
@@ -13,8 +12,11 @@ def test_query_stat_statements(sess):
     )).fetchone()
 
     if int(pg_version) < 140000:
-        pytest.skip("Skipping fixture on pg version < 14. The query_id column on pg_stat_statements is only available on >= 14")
+        pytest.skip(
+            "Skipping fixture on pg version < 14. The query_id column on pg_stat_statements is only available on >= 14")
 
+
+def create_pg_stat_statement(sess):
     sess.execute(text(
         """
         create extension pg_stat_statements;
@@ -23,33 +25,8 @@ def test_query_stat_statements(sess):
 
     sess.commit()
 
-    time.sleep(1)
 
-    (old_calls,) = sess.execute(text(
-        """
-        select coalesce(sum(calls), 0)
-        from pg_stat_statements
-        where
-            query ilike '%DELETE FROM net._http_response r %' or
-            query ilike '%DELETE FROM net.http_request_queue%';
-    """
-    )).fetchone()
-
-    # sleep for some time to see if new queries arrive
-    time.sleep(3)
-
-    (new_calls,) = sess.execute(text(
-        """
-        select coalesce(sum(calls), 0)
-        from pg_stat_statements
-        where
-            query ilike '%DELETE FROM net._http_response r %' or
-            query ilike '%DELETE FROM net.http_request_queue%';
-    """
-    )).fetchone()
-
-    assert new_calls == old_calls
-
+def drop_pg_stat_statement(sess):
     sess.execute(text(
         """
         select pg_stat_statements_reset();
@@ -60,30 +37,8 @@ def test_query_stat_statements(sess):
     sess.commit()
 
 
-def test_wakes_at_commit_time(sess):
-    """Check that the background worker only does one wake at commit time, avoiding unnecessary wakes and work"""
-
-    (pg_version,) = sess.execute(text(
-        """
-        select current_setting('server_version_num');
-    """
-    )).fetchone()
-
-    if int(pg_version) < 140000:
-        pytest.skip("Skipping fixture on pg version < 14. The query_id column on pg_stat_statements is only available on >= 14")
-
-    sess.execute(text(
-        """
-        create extension pg_stat_statements;
-    """
-    ))
-
-    sess.commit()
-
-    # wait for initial queries
-    time.sleep(1)
-
-    (initial_calls,) = sess.execute(text(
+def get_worker_query_count(sess):
+    (count,) = sess.execute(text(
         """
         select coalesce(sum(calls), 0)
         from pg_stat_statements
@@ -93,31 +48,62 @@ def test_wakes_at_commit_time(sess):
     """
     )).fetchone()
 
+    return count
+
+
+def test_query_stat_statements(sess):
+    """
+    Check that the background worker doesn't execute
+    queries when no new requests arrive
+    """
+
+    skip_test_if_pg_is_old(sess)
+
+    create_pg_stat_statement(sess)
+
+    old_calls = get_worker_query_count(sess)
+
+    # sleep for some time to see if new queries arrive
+    time.sleep(3)
+
+    new_calls = get_worker_query_count(sess)
+
+    assert new_calls == old_calls
+
+    drop_pg_stat_statement(sess)
+
+
+def test_wakes_at_commit_time(sess):
+    """
+    Check that the background worker only does one wake at
+    commit time, avoiding unnecessary wakes and work
+    """
+
+    skip_test_if_pg_is_old(sess)
+
+    create_pg_stat_statement(sess)
+
+    # wait for initial queries
+    time.sleep(1)
+
+    initial_calls = get_worker_query_count(sess)
+
     assert initial_calls >= 0
 
-    sess.execute(text(
+    http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,100);
     """
     ))
 
-    sess.commit()
-
     # wait for reqs
     time.sleep(2)
 
-    (commit_calls,) = sess.execute(text(
-        """
-        select coalesce(sum(calls), 0)
-        from pg_stat_statements
-        where
-            query ilike '%DELETE FROM net._http_response r %' or
-            query ilike '%DELETE FROM net.http_request_queue%';
-    """
-    )).fetchone()
+    commit_calls = get_worker_query_count(sess)
 
-    assert commit_calls == initial_calls + 4 # only 4 queries should be made for the above requests
-                                             # 2 queries at wake, 2 extra to check if there are more rows to be processed
+    # only 4 queries should be made for the above requests
+    # 2 queries at wake, 2 extra to check if there are more rows to be processed
+    assert commit_calls == initial_calls + 4
 
     # if the new requests are rollbacked/aborted, then no new queries will be made by the bg worker
     sess.execute(text(
@@ -131,23 +117,8 @@ def test_wakes_at_commit_time(sess):
     # wait for requests
     time.sleep(2)
 
-    (rollback_calls,) = sess.execute(text(
-        """
-        select coalesce(sum(calls), 0)
-        from pg_stat_statements
-        where
-            query ilike '%DELETE FROM net._http_response r %' or
-            query ilike '%DELETE FROM net.http_request_queue%';
-    """
-    )).fetchone()
+    rollback_calls = get_worker_query_count(sess)
 
     assert rollback_calls == commit_calls
 
-    sess.execute(text(
-        """
-        select pg_stat_statements_reset();
-        drop extension pg_stat_statements;
-    """
-    ))
-
-    sess.commit()
+    drop_pg_stat_statement(sess)

--- a/test/test_stat_statements.py
+++ b/test/test_stat_statements.py
@@ -2,6 +2,7 @@ import time
 
 import pytest
 from sqlalchemy import text
+from common import http_request
 
 
 def test_query_stat_statements(sess):
@@ -104,13 +105,11 @@ def test_wakes_at_commit_time(sess):
 
     assert initial_calls >= 0
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,100);
     """
     ))
-
-    sess.commit()
 
     # wait for reqs
     time.sleep(2)

--- a/test/test_stat_statements.py
+++ b/test/test_stat_statements.py
@@ -5,12 +5,7 @@ from sqlalchemy import text
 from common import http_request
 
 
-def test_query_stat_statements(sess):
-    """
-    Check that the background worker doesn't execute
-    queries when no new requests arrive
-    """
-
+def skip_test_if_pg_is_old(sess):
     (pg_version,) = sess.execute(text(
         """
         select current_setting('server_version_num');
@@ -21,6 +16,8 @@ def test_query_stat_statements(sess):
         pytest.skip(
             "Skipping fixture on pg version < 14. The query_id column on pg_stat_statements is only available on >= 14")
 
+
+def create_pg_stat_statement(sess):
     sess.execute(text(
         """
         create extension pg_stat_statements;
@@ -29,31 +26,8 @@ def test_query_stat_statements(sess):
 
     sess.commit()
 
-    (old_calls,) = sess.execute(text(
-        """
-        select coalesce(sum(calls), 0)
-        from pg_stat_statements
-        where
-            query ilike '%DELETE FROM net._http_response r %' or
-            query ilike '%DELETE FROM net.http_request_queue%';
-    """
-    )).fetchone()
 
-    # sleep for some time to see if new queries arrive
-    time.sleep(3)
-
-    (new_calls,) = sess.execute(text(
-        """
-        select coalesce(sum(calls), 0)
-        from pg_stat_statements
-        where
-            query ilike '%DELETE FROM net._http_response r %' or
-            query ilike '%DELETE FROM net.http_request_queue%';
-    """
-    )).fetchone()
-
-    assert new_calls == old_calls
-
+def drop_pg_stat_statement(sess):
     sess.execute(text(
         """
         select pg_stat_statements_reset();
@@ -64,34 +38,8 @@ def test_query_stat_statements(sess):
     sess.commit()
 
 
-def test_wakes_at_commit_time(sess):
-    """
-    Check that the background worker only does one wake at
-    commit time, avoiding unnecessary wakes and work
-    """
-
-    (pg_version,) = sess.execute(text(
-        """
-        select current_setting('server_version_num');
-    """
-    )).fetchone()
-
-    if int(pg_version) < 140000:
-        pytest.skip(
-            "Skipping fixture on pg version < 14. The query_id column on pg_stat_statements is only available on >= 14")
-
-    sess.execute(text(
-        """
-        create extension pg_stat_statements;
-    """
-    ))
-
-    sess.commit()
-
-    # wait for initial queries
-    time.sleep(1)
-
-    (initial_calls,) = sess.execute(text(
+def get_worker_query_count(sess):
+    (count,) = sess.execute(text(
         """
         select coalesce(sum(calls), 0)
         from pg_stat_statements
@@ -100,6 +48,46 @@ def test_wakes_at_commit_time(sess):
             query ilike '%DELETE FROM net.http_request_queue%';
     """
     )).fetchone()
+
+    return count
+
+
+def test_query_stat_statements(sess):
+    """
+    Check that the background worker doesn't execute
+    queries when no new requests arrive
+    """
+
+    skip_test_if_pg_is_old(sess)
+
+    create_pg_stat_statement(sess)
+
+    old_calls = get_worker_query_count(sess)
+
+    # sleep for some time to see if new queries arrive
+    time.sleep(3)
+
+    new_calls = get_worker_query_count(sess)
+
+    assert new_calls == old_calls
+
+    drop_pg_stat_statement(sess)
+
+
+def test_wakes_at_commit_time(sess):
+    """
+    Check that the background worker only does one wake at
+    commit time, avoiding unnecessary wakes and work
+    """
+
+    skip_test_if_pg_is_old(sess)
+
+    create_pg_stat_statement(sess)
+
+    # wait for initial queries
+    time.sleep(1)
+
+    initial_calls = get_worker_query_count(sess)
 
     assert initial_calls >= 0
 
@@ -112,15 +100,7 @@ def test_wakes_at_commit_time(sess):
     # wait for reqs
     time.sleep(2)
 
-    (commit_calls,) = sess.execute(text(
-        """
-        select coalesce(sum(calls), 0)
-        from pg_stat_statements
-        where
-            query ilike '%DELETE FROM net._http_response r %' or
-            query ilike '%DELETE FROM net.http_request_queue%';
-    """
-    )).fetchone()
+    commit_calls = get_worker_query_count(sess)
 
     # only 4 queries should be made for the above requests
     # 2 queries at wake, 2 extra to check if there are more rows to be processed
@@ -138,23 +118,8 @@ def test_wakes_at_commit_time(sess):
     # wait for requests
     time.sleep(2)
 
-    (rollback_calls,) = sess.execute(text(
-        """
-        select coalesce(sum(calls), 0)
-        from pg_stat_statements
-        where
-            query ilike '%DELETE FROM net._http_response r %' or
-            query ilike '%DELETE FROM net.http_request_queue%';
-    """
-    )).fetchone()
+    rollback_calls = get_worker_query_count(sess)
 
     assert rollback_calls == commit_calls
 
-    sess.execute(text(
-        """
-        select pg_stat_statements_reset();
-        drop extension pg_stat_statements;
-    """
-    ))
-
-    sess.commit()
+    drop_pg_stat_statement(sess)

--- a/test/test_stat_statements.py
+++ b/test/test_stat_statements.py
@@ -1,5 +1,4 @@
 import time
-
 import pytest
 from sqlalchemy import text
 from common import http_request

--- a/test/test_stat_statements.py
+++ b/test/test_stat_statements.py
@@ -29,8 +29,6 @@ def test_query_stat_statements(sess):
 
     sess.commit()
 
-    time.sleep(1)
-
     (old_calls,) = sess.execute(text(
         """
         select coalesce(sum(calls), 0)
@@ -125,8 +123,8 @@ def test_wakes_at_commit_time(sess):
     )).fetchone()
 
     # only 4 queries should be made for the above requests
-    assert commit_calls == initial_calls + 4
     # 2 queries at wake, 2 extra to check if there are more rows to be processed
+    assert commit_calls == initial_calls + 4
 
     # if the new requests are rollbacked/aborted, then no new queries will be made by the bg worker
     sess.execute(text(

--- a/test/test_stat_statements.py
+++ b/test/test_stat_statements.py
@@ -5,7 +5,10 @@ from sqlalchemy import text
 
 
 def test_query_stat_statements(sess):
-    """Check that the background worker doesn't execute queries when no new requests arrive"""
+    """
+    Check that the background worker doesn't execute
+    queries when no new requests arrive
+    """
 
     (pg_version,) = sess.execute(text(
         """
@@ -63,7 +66,10 @@ def test_query_stat_statements(sess):
 
 
 def test_wakes_at_commit_time(sess):
-    """Check that the background worker only does one wake at commit time, avoiding unnecessary wakes and work"""
+    """
+    Check that the background worker only does one wake at
+    commit time, avoiding unnecessary wakes and work
+    """
 
     (pg_version,) = sess.execute(text(
         """

--- a/test/test_stat_statements.py
+++ b/test/test_stat_statements.py
@@ -1,7 +1,7 @@
 import time
 import pytest
 from sqlalchemy import text
-from common import http_request
+from common import http_requests
 
 
 def skip_test_if_pg_is_old(sess):
@@ -90,7 +90,7 @@ def test_wakes_at_commit_time(sess):
 
     assert initial_calls >= 0
 
-    http_request(sess, text(
+    http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,100);
     """

--- a/test/test_stat_statements.py
+++ b/test/test_stat_statements.py
@@ -3,6 +3,7 @@ import time
 import pytest
 from sqlalchemy import text
 
+
 def test_query_stat_statements(sess):
     """Check that the background worker doesn't execute queries when no new requests arrive"""
 
@@ -13,7 +14,8 @@ def test_query_stat_statements(sess):
     )).fetchone()
 
     if int(pg_version) < 140000:
-        pytest.skip("Skipping fixture on pg version < 14. The query_id column on pg_stat_statements is only available on >= 14")
+        pytest.skip(
+            "Skipping fixture on pg version < 14. The query_id column on pg_stat_statements is only available on >= 14")
 
     sess.execute(text(
         """
@@ -70,7 +72,8 @@ def test_wakes_at_commit_time(sess):
     )).fetchone()
 
     if int(pg_version) < 140000:
-        pytest.skip("Skipping fixture on pg version < 14. The query_id column on pg_stat_statements is only available on >= 14")
+        pytest.skip(
+            "Skipping fixture on pg version < 14. The query_id column on pg_stat_statements is only available on >= 14")
 
     sess.execute(text(
         """
@@ -116,8 +119,9 @@ def test_wakes_at_commit_time(sess):
     """
     )).fetchone()
 
-    assert commit_calls == initial_calls + 4 # only 4 queries should be made for the above requests
-                                             # 2 queries at wake, 2 extra to check if there are more rows to be processed
+    # only 4 queries should be made for the above requests
+    assert commit_calls == initial_calls + 4
+    # 2 queries at wake, 2 extra to check if there are more rows to be processed
 
     # if the new requests are rollbacked/aborted, then no new queries will be made by the bg worker
     sess.execute(text(

--- a/test/test_user_db.py
+++ b/test/test_user_db.py
@@ -1,30 +1,33 @@
-import time
-
-import pytest
 from sqlalchemy import text
+from common import restart_worker
+
 
 def test_net_with_different_username_dbname(sess, autocommit_sess):
     """Check that a pre existing role can use the net schema"""
 
-    autocommit_sess.execute(text("alter system set pg_net.username to 'pre_existing'"))
-    autocommit_sess.execute(text("alter system set pg_net.database_name to 'pre_existing'"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    try:
+        autocommit_sess.execute(
+            text("alter system set pg_net.username to 'pre_existing'"))
+        autocommit_sess.execute(
+            text("alter system set pg_net.database_name to 'pre_existing'"))
+        restart_worker(autocommit_sess)
 
-    (username,datname) = sess.execute(
-        text(
-            """
-        select usename, datname from pg_stat_activity where backend_type ilike '%pg_net%';
-    """
-        )
-    ).fetchone()
-    assert username == 'pre_existing'
-    assert datname == 'pre_existing'
+        (username, datname) = sess.execute(
+            text(
+                """
+            select usename, datname from pg_stat_activity where backend_type ilike '%pg_net%';
+        """
+            )
+        ).fetchone()
+        assert username == 'pre_existing'
+        assert datname == 'pre_existing'
 
-    autocommit_sess.execute(text("alter system reset pg_net.username"))
-    autocommit_sess.execute(text("alter system reset pg_net.database_name"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.username"))
+        autocommit_sess.execute(
+            text("alter system reset pg_net.database_name"))
+        restart_worker(autocommit_sess)
+
 
 def test_net_appname(sess):
     """Check that pg_stat_activity has appname set"""

--- a/test/test_user_db.py
+++ b/test/test_user_db.py
@@ -10,8 +10,7 @@ def test_net_with_different_username_dbname(sess, autocommit_sess):
             text("alter system set pg_net.username to 'pre_existing'"))
         autocommit_sess.execute(
             text("alter system set pg_net.database_name to 'pre_existing'"))
-        autocommit_sess.execute(text("select net.worker_restart()"))
-        autocommit_sess.execute(text("select net.wait_until_running()"))
+        restart_worker(autocommit_sess)
 
         (username, datname) = sess.execute(
             text(

--- a/test/test_user_db.py
+++ b/test/test_user_db.py
@@ -1,6 +1,3 @@
-import time
-
-import pytest
 from sqlalchemy import text
 
 

--- a/test/test_user_db.py
+++ b/test/test_user_db.py
@@ -4,27 +4,30 @@ from sqlalchemy import text
 def test_net_with_different_username_dbname(sess, autocommit_sess):
     """Check that a pre existing role can use the net schema"""
 
-    autocommit_sess.execute(
-        text("alter system set pg_net.username to 'pre_existing'"))
-    autocommit_sess.execute(
-        text("alter system set pg_net.database_name to 'pre_existing'"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    try:
+        autocommit_sess.execute(
+            text("alter system set pg_net.username to 'pre_existing'"))
+        autocommit_sess.execute(
+            text("alter system set pg_net.database_name to 'pre_existing'"))
+        autocommit_sess.execute(text("select net.worker_restart()"))
+        autocommit_sess.execute(text("select net.wait_until_running()"))
 
-    (username, datname) = sess.execute(
-        text(
-            """
-        select usename, datname from pg_stat_activity where backend_type ilike '%pg_net%';
-    """
-        )
-    ).fetchone()
-    assert username == 'pre_existing'
-    assert datname == 'pre_existing'
+        (username, datname) = sess.execute(
+            text(
+                """
+            select usename, datname from pg_stat_activity where backend_type ilike '%pg_net%';
+        """
+            )
+        ).fetchone()
+        assert username == 'pre_existing'
+        assert datname == 'pre_existing'
 
-    autocommit_sess.execute(text("alter system reset pg_net.username"))
-    autocommit_sess.execute(text("alter system reset pg_net.database_name"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.username"))
+        autocommit_sess.execute(
+            text("alter system reset pg_net.database_name"))
+        autocommit_sess.execute(text("select net.worker_restart()"))
+        autocommit_sess.execute(text("select net.wait_until_running()"))
 
 
 def test_net_appname(sess):

--- a/test/test_user_db.py
+++ b/test/test_user_db.py
@@ -1,4 +1,5 @@
 from sqlalchemy import text
+from common import restart_worker
 
 
 def test_net_with_different_username_dbname(sess, autocommit_sess):
@@ -26,8 +27,7 @@ def test_net_with_different_username_dbname(sess, autocommit_sess):
         autocommit_sess.execute(text("alter system reset pg_net.username"))
         autocommit_sess.execute(
             text("alter system reset pg_net.database_name"))
-        autocommit_sess.execute(text("select net.worker_restart()"))
-        autocommit_sess.execute(text("select net.wait_until_running()"))
+        restart_worker(autocommit_sess)
 
 
 def test_net_appname(sess):

--- a/test/test_user_db.py
+++ b/test/test_user_db.py
@@ -3,15 +3,18 @@ import time
 import pytest
 from sqlalchemy import text
 
+
 def test_net_with_different_username_dbname(sess, autocommit_sess):
     """Check that a pre existing role can use the net schema"""
 
-    autocommit_sess.execute(text("alter system set pg_net.username to 'pre_existing'"))
-    autocommit_sess.execute(text("alter system set pg_net.database_name to 'pre_existing'"))
+    autocommit_sess.execute(
+        text("alter system set pg_net.username to 'pre_existing'"))
+    autocommit_sess.execute(
+        text("alter system set pg_net.database_name to 'pre_existing'"))
     autocommit_sess.execute(text("select net.worker_restart()"))
     autocommit_sess.execute(text("select net.wait_until_running()"))
 
-    (username,datname) = sess.execute(
+    (username, datname) = sess.execute(
         text(
             """
         select usename, datname from pg_stat_activity where backend_type ilike '%pg_net%';
@@ -25,6 +28,7 @@ def test_net_with_different_username_dbname(sess, autocommit_sess):
     autocommit_sess.execute(text("alter system reset pg_net.database_name"))
     autocommit_sess.execute(text("select net.worker_restart()"))
     autocommit_sess.execute(text("select net.wait_until_running()"))
+
 
 def test_net_appname(sess):
     """Check that pg_stat_activity has appname set"""

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -1,14 +1,17 @@
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
-from sqlalchemy import text
-import sqlalchemy as sa
-import pytest
 import time
 import subprocess
 import os
+from common import http_request, http_requests, restart_worker, wait_for_any_response
+from common import wait_for_extension_drop, wait_for_postgres_ready
+from common import wait_for_queue_drain, wait_for_response_count
+from common import wait_for_worker_down, wait_for_worker_state
+from common import wait_for_worker_up, wait_until, wakeup_worker
+
 
 def test_worker_will_not_block_drop_database(autocommit_sess):
-    """the worker will not block a session doing drop database"""
+    """Check that the worker will not block a session doing drop database"""
 
     autocommit_sess.execute(text("create database foo;"))
     autocommit_sess.execute(text("drop database foo;"))
@@ -51,169 +54,153 @@ def test_success_when_worker_is_up(sess):
     assert result == ''
 
 
-def test_worker_will_process_queue_when_up(sess):
-    """when pg background worker is down and requests arrive, it will process them once it wakes up"""
+def test_worker_will_process_queue_when_up(sess, autocommit_sess):
+    """
+    Check that when pg background worker is down and requests arrive,
+    it will process them once it wakes up
+    """
 
-    # check worker up
-    (up,) = sess.execute(text("""
+    # Assert that background worker is worker up
+    (worker_is_up,) = sess.execute(text("""
         select is_worker_up();
     """)).fetchone()
-    assert up is not None
-    assert up == True
+    assert worker_is_up
 
-    # restart it
-    (restarted,) = sess.execute(text("""
+    # kill background worker
+    (killed,) = sess.execute(text("""
         select public.kill_worker();
     """)).fetchone()
-    assert restarted is not None
-    assert restarted == True
+    assert killed is not None
+    assert killed == True
 
-    time.sleep(0.1)
+    # Wait for background worker to go down
+    wait_for_worker_down(autocommit_sess)
 
-    # check worker down
-    (up,) = sess.execute(text("""
-        select is_worker_up();
-    """)).fetchone()
-    assert up is not None
-    assert up == False
-
-    sess.execute(text(
+    # Make a request while the worker is down
+    http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
     """
-    )).fetchone()
+    ))
 
-    sess.commit()
-
-    # check requests where enqueued
+    # Check that requests were enqueued
     (count,) = sess.execute(text(
-    """
+        """
         select count(*) from net.http_request_queue;
     """
     )).fetchone()
-
     assert count == 10
 
-    # check worker is still down
-    (up,) = sess.execute(text("""
+    # Check that worker is still down. Note that this is a bit racy
+    # as there is no guarantee that worker hasn't come back up at this
+    # time, but in practice this rarely fails because worker takes 2
+    # seconds before coming back up, which is more than enough time
+    # to reach here.
+    (worker_is_up,) = sess.execute(text("""
         select is_worker_up();
     """)).fetchone()
-    assert up is not None
-    assert up == False
+    assert not worker_is_up
 
     sess.commit()
 
-    # wait until up
-    time.sleep(2.1)
+    # Wait for background worker to come back up
+    # It's critical to use autocommit_sess to see a new snapshot
+    # on each retry in wait_until, otherwise it might keep reading
+    # stale data and fail with a timeout.
+    wait_for_worker_up(autocommit_sess)
 
-    # check worker up
-    (up,) = sess.execute(text("""
-        select is_worker_up();
-    """)).fetchone()
-    assert up is not None
-    assert up == True
+    # Wait for request queue to drain
+    wait_for_queue_drain(autocommit_sess)
 
-    # wait until new requests are done
-    time.sleep(1.1)
-
-    (count,) = sess.execute(text(
-    """
-        select count(*) from net.http_request_queue;
-    """
-    )).fetchone()
-
-    assert count == 0
-
-    (status_code,count) = sess.execute(text(
-    """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
-
-    assert status_code == 200
-    assert count == 10
+    # Wait until all responses have arrived
+    wait_for_response_count(autocommit_sess, 10)
 
 
 def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
-    """user can delete the queue rows while the worker is processing them"""
-
-    autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
-    autocommit_sess.execute(text("select net.worker_restart();"))
-    autocommit_sess.execute(text("select net.wait_until_running();"))
-
-    sess.execute(text(
-        """
-        select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
     """
-    ))
-
-    sess.commit()
-
-    # leave time for some processing
-    time.sleep(0.1)
-
-    (count,) = sess.execute(text(
-        """
-        WITH deleted AS (DELETE FROM net.http_request_queue RETURNING *) SELECT count(*) FROM deleted;
+    Check that a user can delete the queue rows while the worker is
+    processing them
     """
-    )).fetchone()
-    assert count > 1
 
-    sess.commit()
+    try:
+        autocommit_sess.execute(
+            text("alter system set pg_net.batch_size to '1';"))
+        restart_worker(autocommit_sess)
 
-    autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+        http_requests(sess, text(
+            """
+            select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
+        """
+        ))
+
+        # Wait until responses have started arriving
+        wait_for_any_response(autocommit_sess)
+
+        (count,) = sess.execute(text(
+            """
+            with deleted as (delete from net.http_request_queue returning *) select count(*) from deleted;
+        """
+        )).fetchone()
+        assert count > 1
+
+        sess.commit()
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
+        restart_worker(autocommit_sess)
 
 
 def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
-    """a truncate will not wait until the worker is done processing all requests"""
+    """
+    Check that a truncate will not wait until the worker
+    is done processing all requests
+    """
 
-    # ensure the worker will be processing the queue 1 by 1 (slowly) so it doesn't clear the whole
-    # net.http_request_queue in one go
-    autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
-    autocommit_sess.execute(text("select net.worker_restart();"))
-    autocommit_sess.execute(text("select net.wait_until_running();"))
+    try:
+        # ensure the worker will be processing the queue 1 by 1 (slowly) so it doesn't clear the whole
+        # net.http_request_queue in one go
+        autocommit_sess.execute(
+            text("alter system set pg_net.batch_size to '1';"))
+        restart_worker(autocommit_sess)
 
-    sess.execute(text(
+        http_requests(sess, text(
+            """
+            select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
         """
-        select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
+        ))
+
+        # truncate succeeds fast, despite the worker still processing the queue 1 by 1
+        sess.execute(text(
+            """
+            truncate net.http_request_queue;
+        """
+        ))
+
+        # now the queue will be empty
+        (count,) = sess.execute(text(
+            """
+            select count(*) from net.http_request_queue;
+        """
+        )).fetchone()
+        assert count == 0
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
+        restart_worker(autocommit_sess)
+
+
+def test_no_failure_on_drop_extension(sess, autocommit_sess):
+    """
+    Check that while waiting for a slow request, a drop extension should
+    wait and not crash the worker
+    """
+
+    http_requests(sess, text(
+        """
+        select net.http_get('http://localhost:8080/pathological?status=200&delay=2') from generate_series(1,10);
     """
     ))
-    sess.commit()
 
-    # truncate succeeds fast, despite the worker still processing the queue 1 by 1
-    sess.execute(text(
-        """
-        truncate net.http_request_queue;
-    """
-    ))
-
-    # now the queue will be empty
-    (count,) = sess.execute(text(
-        """
-        select count(*) from net.http_request_queue;
-    """
-    )).fetchone()
-    assert count == 0
-
-    autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
-
-
-def test_no_failure_on_drop_extension(sess):
-    """while waiting for a slow request, a drop extension should wait and not crash the worker"""
-
-    (request_id,) = sess.execute(text("""
-        select net.http_get(url := 'http://localhost:8080/pathological?status=200&delay=2');
-    """)).fetchone()
-    assert request_id == 1
-
-    sess.commit()
-
-    # wait until processing
-    time.sleep(1)
+    # Wait until responses have started arriving
+    wait_for_any_response(autocommit_sess)
 
     sess.execute(text("""
         drop extension pg_net cascade;
@@ -221,9 +208,10 @@ def test_no_failure_on_drop_extension(sess):
 
     sess.commit()
 
-    # wait until request is finished
-    time.sleep(3)
+    # wait until the extension is fully gone
+    wait_for_extension_drop(autocommit_sess)
 
+    # The background worker should not have crash even after dropping the extension
     (up,) = sess.execute(text("""
         select is_worker_up();
     """)).fetchone()
@@ -232,94 +220,80 @@ def test_no_failure_on_drop_extension(sess):
 
 
 def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess):
-    """when the background worker is restarted while working, it will pick up the remaining requests"""
+    """
+    Check that when the background worker is restarted while working,
+    it will pick up the remaining requests
+    """
 
-    autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
-    autocommit_sess.execute(text("select net.worker_restart();"))
-    autocommit_sess.execute(text("select net.wait_until_running();"))
+    try:
+        autocommit_sess.execute(
+            text("alter system set pg_net.batch_size to '1';"))
+        restart_worker(autocommit_sess)
 
-    sess.execute(text(
+        http_requests(sess, text(
+            """
+            select net.http_get('http://localhost:8080/pathological?status=200&delay=1') from generate_series(1,5);
         """
-        select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,5);
-    """
-    ))
+        ))
 
-    sess.commit()
+        # Wait until responses have started arriving
+        (processed,) = wait_until(
+            fetch=lambda: autocommit_sess.execute(text("""
+                select count(*) from net._http_response;
+            """)).fetchone(),
+            predicate=lambda result: result[0] > 0,
+            timeout=5,
+            sleep_interval=0.1,
+            description="responses to arrive before first restart",
+        )
 
-    # one restart will likely keep the worker awake since the wake signal could still be on, so do two restarts
-    # to ensure the wake signal is cleared
-    sess.execute(text(
-        """
-        select net.worker_restart();
-        select net.wait_until_running();
-    """
-    ))
+        restart_worker(autocommit_sess)
 
-    time.sleep(0.1)
+        # Check that more requests are processed after a restart
+        wait_until(
+            fetch=lambda: autocommit_sess.execute(text("""
+                select count(*) from net._http_response;
+            """)).fetchone(),
+            predicate=lambda result: result[0] >= processed,
+            timeout=5,
+            sleep_interval=0.1,
+            description="responses to arrive after first restart",
+        )
 
-    sess.execute(text(
-        """
-        select net.worker_restart();
-        select net.wait_until_running();
-    """
-    ))
+        restart_worker(autocommit_sess)
 
-    time.sleep(0.1)
+        # And now wait until all responses have arrived
+        wait_for_response_count(autocommit_sess, 5)
 
-    (status_code,count) = sess.execute(text(
-    """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
-
-    # at most 2 requests should have finished by now because of the low batch_size
-    assert count <= 2
-    assert count > 0 # at least 1 request should be finished
-    assert status_code == 200
-
-    # if we sleep for 4 seconds the whole 5 requests should be finished
-    time.sleep(4)
-
-    (status_code,count) = sess.execute(text(
-    """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
-
-    assert status_code == 200
-    assert count == 5
-
-    autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
+        restart_worker(autocommit_sess)
 
 
-def test_new_requests_get_attended_asap(sess):
-    """new requests get attended as soon as possible"""
+def test_new_requests_get_attended_without_explicit_wakeup(sess, autocommit_sess):
+    """Check that new requests get attended without an explicit wakeup"""
 
-    sess.execute(text(
+    http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
     """
     ))
 
-    sess.commit()
+    # wait until all responses have arrived
+    wait_for_response_count(autocommit_sess, 10)
 
-    # less than a second
-    time.sleep(0.1)
 
-    (status_code,count) = sess.execute(text(
+def test_direct_inserts_no_requests(sess, autocommit_sess):
     """
-        select status_code, count(*) from net._http_response group by status_code;
+    Check that direct insertions to the net.http_request_queue doesn't
+    trigger new requests
     """
-    )).fetchone()
 
-    assert status_code == 200
-    assert count == 10
-
-
-def test_direct_inserts_no_requests(sess):
-    """direct insertions to the net.http_request_queue doesn't trigger new requests"""
+    # Make sure the worker has already settled into its idle wait before we
+    # insert. If a prior test left it mid-batch, its trailing WORKER_WAIT_ONE_SECOND
+    # recheck (worker.c) can pick up this test's direct insert on its own,
+    # with no net.wake() involved, and make this test flake.
+    wait_for_worker_state(autocommit_sess, 'idle')
 
     sess.execute(text(
         """
@@ -335,117 +309,99 @@ def test_direct_inserts_no_requests(sess):
 
     sess.commit()
 
-    # wait for req
-    time.sleep(0.1)
+    # Even waiting for 5 seconds doesn't process the request
+    time.sleep(5)
 
-    # no response
+    # No response still
     (count,) = sess.execute(text(
-    """
+        """
         select count(*) from net._http_response;
     """
     )).fetchone()
 
     assert count == 0
 
-    # req still in queue
+    # Reqest is still in queue
     (count,) = sess.execute(text(
-    """
-        select count(*) from net.http_request_queue;
-    """
-    )).fetchone()
-
-    assert count == 1
-
-    # an explicit wake will make it serve requests though
-
-    sess.execute(text(
-    """
-        select net.wake();
-    """
-    ))
-
-    sess.commit()
-
-    # wait for req
-    time.sleep(0.1)
-
-    (status_code, count) = sess.execute(text(
-    """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
-
-    assert status_code == 200
-    assert count == 1
-
-
-def test_processing_survives_postmaster_crash():
-    """the queue will continue processing even when a postmaster crash or restart happens"""
-
-    engine = create_engine("postgresql:///postgres")
-    ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
-    tmp_sess = Session(ac_engine)
-
-    tmp_sess.execute(text("create extension if not exists pg_net;"))
-
-    tmp_sess.execute(text("alter system set pg_net.batch_size to '5';"))
-    tmp_sess.execute(text("select net.worker_restart();"))
-    tmp_sess.execute(text("select net.wait_until_running();"))
-
-    tmp_sess.execute(text(
         """
-        select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
-    """
-    )).fetchone()
-
-    (count,) = tmp_sess.execute(text(
-    """
         select count(*) from net.http_request_queue;
     """
     )).fetchone()
-    assert count == 10
 
-    engine.dispose()
+    assert count == 1
 
-    pgdata_env = os.getenv('PGDATA')
-    subprocess.run(["pg_ctl", "restart", "-D", pgdata_env])
+    # An explicit wake will make it serve requests though
+    wakeup_worker(sess)
 
-    # give it some time to finish restart
-    time.sleep(1)
+    # wait until the response has arrived
+    wait_for_response_count(autocommit_sess, 1)
+
+
+def test_processing_survives_postmaster_crash(autocommit_sess):
+    """
+    Check that the queue will continue processing even when a postmaster
+    crash or restart happens
+    """
 
     engine = create_engine("postgresql:///postgres")
     ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
     tmp_sess = Session(ac_engine)
 
-    # give it enough time to finish processing the queue
-    time.sleep(1)
+    try:
+        tmp_sess.execute(text("create extension if not exists pg_net;"))
 
-    (count,) = tmp_sess.execute(text(
-    """
-        select count(*) from net.http_request_queue;
-    """
-    )).fetchone()
-    assert count == 0
+        tmp_sess.execute(text("alter system set pg_net.batch_size to '5';"))
+        restart_worker(tmp_sess)
 
-    (status_code,count) = tmp_sess.execute(text(
-    """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
+        tmp_sess.execute(text(
+            """
+            select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
+        """
+        )).fetchone()
 
-    assert status_code == 200
-    assert count == 10
+        (count,) = tmp_sess.execute(text(
+            """
+            select count(*) from net.http_request_queue;
+        """
+        )).fetchone()
+        assert count == 10
 
-    tmp_sess.execute(text("alter system reset pg_net.batch_size"))
-    tmp_sess.execute(text("select net.worker_restart()"))
-    tmp_sess.execute(text("select net.wait_until_running()"))
+        engine.dispose()
 
-    engine.dispose()
+        pgdata_env = os.getenv('PGDATA')
+        subprocess.run(["pg_ctl", "restart", "-D", pgdata_env])
+
+        # wait for postmaster to finish restarting and accept connections
+        wait_for_postgres_ready(engine, tmp_sess)
+
+        # Recreate engine and session after restart
+        engine = create_engine("postgresql:///postgres")
+        ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
+        tmp_sess = Session(ac_engine)
+
+        # wait until the queue has finished processing
+        wait_for_queue_drain(autocommit_sess)
+
+        (status_code, count) = tmp_sess.execute(text(
+            """
+            select status_code, count(*) from net._http_response group by status_code;
+        """
+        )).fetchone()
+
+        assert status_code == 200
+        assert count == 10
+
+    finally:
+        tmp_sess.execute(text("alter system reset pg_net.batch_size"))
+        restart_worker(autocommit_sess)
+
+        engine.dispose()
 
 
 def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
-    """the worker's INSERTs into net._http_response must be reflected in
-    pg_stat_user_tables. Without this, autovacuum/autoanalyze can never be
+    """
+    Check that the worker's INSERTs into net._http_response must be reflected
+    in pg_stat_user_tables. Without this, autovacuum/autoanalyze can never be
     scheduled and the table silently bloats.
     """
 
@@ -459,22 +415,23 @@ def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
     ))
 
     # Drive a batch of requests through the worker.
-    sess.execute(text("""
+    http_requests(sess, text("""
         select net.http_get('http://localhost:8080/pathological?status=200')
         from generate_series(1,30);
     """))
-    sess.commit()
 
     # Wait until the worker has actually drained the queue and written all
     # responses to net._http_response. Don't assume "30 rows" - the worker
     # may pick up the queue in chunks depending on wake() coalescing.
-    for _ in range(20):
-        time.sleep(0.5)
-        (queue_count,) = sess.execute(text(
+    wait_until(
+        fetch=lambda: sess.execute(text(
             "select count(*) from net.http_request_queue;"
-        )).fetchone()
-        if queue_count == 0:
-            break
+        )).fetchone(),
+        predicate=lambda result: result[0] == 0,
+        timeout=10,
+        sleep_interval=0.5,
+        description="worker to drain the request queue",
+    )
 
     # Confirm the worker actually wrote rows, otherwise the pgstat assertion
     # below would be meaningless.
@@ -488,17 +445,16 @@ def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
     # worker's first flush attempt is normally a hit (last_flush is far in
     # the past after a long idle), but we allow generous slack here so an
     # off-by-a-tick scheduling doesn't flake the suite.
-    deadline = time.time() + 30.0
-    resp_ins = 0
-    resp_mod = 0
-    while time.time() < deadline:
-        (resp_ins, resp_mod) = autocommit_sess.execute(text("""
+    (resp_ins, resp_mod) = wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
             select n_tup_ins, n_mod_since_analyze
             from pg_stat_user_tables where relname='_http_response';
-        """)).fetchone()
-        if resp_ins > 0:
-            break
-        time.sleep(0.5)
+        """)).fetchone(),
+        predicate=lambda result: result[0] > 0,
+        timeout=30,
+        sleep_interval=0.5,
+        description="net._http_response pgstat counters to reflect worker INSERTs",
+    )
 
     assert resp_ins > 0, (
         f"net._http_response.n_tup_ins is still 0 after 30s. "
@@ -513,85 +469,98 @@ def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
 
 
 def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_sess):
-    """autoanalyze on net._http_response must fire after the worker writes
-    enough rows. Without working pgstat counters, autovacuum/autoanalyze
+    """
+    Check that autoanalyze on net._http_response must fire after the worker
+    writes enough rows. Without working pgstat counters, autovacuum/autoanalyze
     never get scheduled and the table bloats - this is the primary symptom
     seen on production (slow expiry DELETEs from a bloated index).
     """
 
-    # Make sure the worker is fully up before we start.
-    autocommit_sess.execute(text("select net.wait_until_running();"))
+    try:
+        # Make sure the worker is fully up before we start.
+        autocommit_sess.execute(text("select net.wait_until_running();"))
 
-    # Make autovacuum eager *before* generating traffic so the launcher is
-    # already running on a 1s naptime by the time stats threshold is crossed.
-    # autovacuum_naptime is PGC_SIGHUP (reloadable). Give the reload a moment
-    # to propagate to the launcher.
-    autocommit_sess.execute(text("alter system set autovacuum_naptime = '1s';"))
-    autocommit_sess.execute(text("select pg_reload_conf();"))
-    time.sleep(1)
+        # Make autovacuum eager *before* generating traffic so the launcher is
+        # already running on a 1s naptime by the time stats threshold is crossed.
+        # autovacuum_naptime is PGC_SIGHUP (reloadable). Give the reload a moment
+        # to propagate to the launcher.
+        autocommit_sess.execute(
+            text("alter system set autovacuum_naptime = '1s';"))
+        autocommit_sess.execute(text("select pg_reload_conf();"))
 
-    # Per-table: trip the autoanalyze threshold after a handful of rows.
-    # Reloptions take effect immediately; no reload required.
-    autocommit_sess.execute(text("""
-        alter table net._http_response set (
-            autovacuum_analyze_threshold = 10,
-            autovacuum_analyze_scale_factor = 0,
-            autovacuum_vacuum_threshold = 10,
-            autovacuum_vacuum_scale_factor = 0
-        );
-    """))
+        wait_until(
+            fetch=lambda: autocommit_sess.execute(text(
+                "select current_setting('autovacuum_naptime');"
+            )).fetchone(),
+            predicate=lambda result: result[0] == '1s',
+            timeout=5,
+            sleep_interval=0.1,
+            description="autovacuum_naptime reload to propagate",
+        )
 
-    autocommit_sess.execute(text(
-        "select pg_stat_reset_single_table_counters('net._http_response'::regclass);"
-    ))
+        # Per-table: trip the autoanalyze threshold after a handful of rows.
+        # Reloptions take effect immediately; no reload required.
+        autocommit_sess.execute(text("""
+            alter table net._http_response set (
+                autovacuum_analyze_threshold = 10,
+                autovacuum_analyze_scale_factor = 0,
+                autovacuum_vacuum_threshold = 10,
+                autovacuum_vacuum_scale_factor = 0
+            );
+        """))
 
-    # Drive 30 inserts through the worker. 30 is well above the threshold (10).
-    sess.execute(text("""
-        select net.http_get('http://localhost:8080/pathological?status=200')
-        from generate_series(1,30);
-    """))
-    sess.commit()
+        autocommit_sess.execute(text(
+            "select pg_stat_reset_single_table_counters('net._http_response'::regclass);"
+        ))
 
-    # 30s budget covers worst-case worker pgstat flush (PGSTAT_MIN_INTERVAL
-    # = 1s slack) + worst-case launcher cycle (autovacuum_max_workers=3,
-    # 3 databases at 1s naptime each ~= 3s/cycle, with 2-3 cycle slack) +
-    # autoanalyze worker spawn + ANALYZE on a tiny table (sub-second).
-    # Real wall time on a clean rig is typically ~2-5s; the slack is to
-    # absorb test-rig load and not flake.
-    deadline = time.time() + 30.0
-    autoanalyze_count = 0
-    while time.time() < deadline:
-        (autoanalyze_count,) = autocommit_sess.execute(text("""
-            select autoanalyze_count
-            from pg_stat_user_tables where relname='_http_response';
-        """)).fetchone()
-        if autoanalyze_count > 0:
-            break
-        time.sleep(0.5)
+        # Drive 30 inserts through the worker. 30 is well above the threshold (10).
+        http_requests(sess, text("""
+            select net.http_get('http://localhost:8080/pathological?status=200')
+            from generate_series(1,30);
+        """))
 
-    assert autoanalyze_count > 0, (
-        "autoanalyze never fired on net._http_response within 30s. "
-        "Worker writes are not making pgstat threshold visible to the "
-        "autovacuum launcher - the customer-facing symptom (silent bloat) "
-        "would manifest in production."
-    )
+        # 30s budget covers worst-case worker pgstat flush (PGSTAT_MIN_INTERVAL
+        # = 1s slack) + worst-case launcher cycle (autovacuum_max_workers=3,
+        # 3 databases at 1s naptime each ~= 3s/cycle, with 2-3 cycle slack) +
+        # autoanalyze worker spawn + ANALYZE on a tiny table (sub-second).
+        # Real wall time on a clean rig is typically ~2-5s; the slack is to
+        # absorb test-rig load and not flake.
+        (autoanalyze_count,) = wait_until(
+            fetch=lambda: autocommit_sess.execute(text("""
+                select autoanalyze_count
+                from pg_stat_user_tables where relname='_http_response';
+            """)).fetchone(),
+            predicate=lambda result: result[0] > 0,
+            timeout=30,
+            sleep_interval=0.5,
+            description="autoanalyze to fire on net._http_response",
+        )
 
-    # Cleanup: restore defaults so we don't bleed into other tests.
-    autocommit_sess.execute(text("""
-        alter table net._http_response reset (
-            autovacuum_analyze_threshold,
-            autovacuum_analyze_scale_factor,
-            autovacuum_vacuum_threshold,
-            autovacuum_vacuum_scale_factor
-        );
-    """))
-    autocommit_sess.execute(text("alter system reset autovacuum_naptime;"))
-    autocommit_sess.execute(text("select pg_reload_conf();"))
+        assert autoanalyze_count > 0, (
+            "autoanalyze never fired on net._http_response within 30s. "
+            "Worker writes are not making pgstat threshold visible to the "
+            "autovacuum launcher - the customer-facing symptom (silent bloat) "
+            "would manifest in production."
+        )
+
+    finally:
+        # Cleanup: restore defaults so we don't bleed into other tests.
+        autocommit_sess.execute(text("""
+            alter table net._http_response reset (
+                autovacuum_analyze_threshold,
+                autovacuum_analyze_scale_factor,
+                autovacuum_vacuum_threshold,
+                autovacuum_vacuum_scale_factor
+            );
+        """))
+        autocommit_sess.execute(text("alter system reset autovacuum_naptime;"))
+        autocommit_sess.execute(text("select pg_reload_conf();"))
 
 
 def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
-    """the pg_net worker must call pgstat_report_activity() so its row in
-    pg_stat_activity has a valid state column.
+    """
+    Check that the pg_net worker must call pgstat_report_activity() so
+    its row in pg_stat_activity has a valid state column.
     """
 
     autocommit_sess.execute(text("select net.wait_until_running();"))
@@ -599,39 +568,21 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
     # Wait for the worker to drain any leftover work from previous tests
     # and settle into idle. Polling makes this robust regardless of what
     # ran before.
-    deadline = time.time() + 5.0
-    state = None
-    while time.time() < deadline:
-        (state,) = autocommit_sess.execute(text(
-            "select state from pg_stat_activity where backend_type ilike '%pg_net%';"
-        )).fetchone()
-        if state == 'idle':
-            break
-        time.sleep(0.1)
-    assert state == 'idle', (
-        f"pg_net worker state expected 'idle' at rest, got {state!r}. "
-        "Without pgstat_report_activity(STATE_IDLE, ...) the state column "
-        "stays NULL."
-    )
+    wait_for_worker_state(autocommit_sess, 'idle')
 
     # Fire a slow request so the worker stays active long enough to observe.
-    sess.execute(text("""
+    http_requests(sess, text("""
         select net.http_get('http://localhost:8080/pathological?status=200&delay=2');
     """))
-    sess.commit()
 
     # Poll for 'active' for up to 5s. The slow request keeps the worker
     # busy for ~2s, so we have a wide observation window.
-    deadline = time.time() + 5.0
     saw_active = False
-    while time.time() < deadline:
-        (state,) = autocommit_sess.execute(text(
-            "select state from pg_stat_activity where backend_type ilike '%pg_net%';"
-        )).fetchone()
-        if state == 'active':
-            saw_active = True
-            break
-        time.sleep(0.1)
+    try:
+        wait_for_worker_state(autocommit_sess, 'active')
+        saw_active = True
+    except AssertionError:
+        pass
 
     assert saw_active, (
         "pg_net worker state was never observed as 'active' during a slow "
@@ -640,11 +591,12 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
     )
 
 
-
 def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_sess):
-    """when a schema named "net" exists but the pg_net tables don't (e.g. another
-    extension installed into a schema named "net"), the worker should treat the
-    extension as not installed instead of crash looping"""
+    """
+    Check that when a schema named "net" exists but the pg_net tables don't
+    (e.g. another extension installed into a schema named "net"), the worker
+    should treat the extension as not installed instead of crash looping
+    """
 
     sess.execute(text("drop extension pg_net cascade;"))
     sess.execute(text("create schema net;"))
@@ -654,26 +606,41 @@ def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_
     autocommit_sess.execute(text("select kill_worker();"))
 
     # wait for the worker to come back up (bgw_restart_time is 1 second)
-    pid = None
-    deadline = time.time() + 5.0
-    while time.time() < deadline:
-        row = autocommit_sess.execute(text(
+    (pid,) = wait_until(
+        fetch=lambda: autocommit_sess.execute(text(
             "select pid from pg_stat_activity where backend_type ilike '%pg_net%';"
-        )).fetchone()
-        if row:
-            pid = row[0]
-            break
-        time.sleep(0.1)
+        )).fetchone(),
+        predicate=lambda result: result,
+        timeout=5,
+        sleep_interval=0.1,
+        description="pg_net worker to to be back up",
+    )
+
     assert pid is not None, "pg_net worker did not come back up after restart"
 
-    # wait several restart cycles; a crash loop would respawn the worker with a new pid
-    time.sleep(3)
+    # Watch for several seconds; a crash loop would respawn the worker with a
+    # new pid. Poll for the bad condition (crash or restart) so we fail as
+    # soon as it happens instead of only checking once at the end of a blind
+    # sleep; a timeout here means the worker stayed up with the same pid.
+    changed = False
+    last_row = None
+    try:
+        last_row = wait_until(
+            fetch=lambda: autocommit_sess.execute(text(
+                "select pid from pg_stat_activity where backend_type ilike '%pg_net%';"
+            )).fetchone(),
+            predicate=lambda result: result is None or result[0] != pid,
+            timeout=3,
+            sleep_interval=0.1,
+            description="pg_net worker to remain stable with the same pid",
+        )
+        changed = True
+    except AssertionError:
+        pass
 
-    row = autocommit_sess.execute(text(
-        "select pid from pg_stat_activity where backend_type ilike '%pg_net%';"
-    )).fetchone()
-    assert row is not None, "pg_net worker is down, it crashed after seeing the net schema"
-    assert row[0] == pid, "pg_net worker restarted, it's crash looping on the net schema"
+    if changed:
+        assert last_row is not None, "pg_net worker is down, it crashed after seeing the net schema"
+        assert last_row[0] == pid, "pg_net worker restarted, it's crash looping on the net schema"
 
     sess.execute(text("drop schema net;"))
     sess.commit()

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -165,8 +165,16 @@ def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
         """
         ))
 
-        # leave time for some processing
-        time.sleep(0.1)
+        # Wait until responses have started arriving
+        wait_until(
+            fetch=lambda: autocommit_sess.execute(text("""
+                select count(*) from net._http_response;
+            """)).fetchone(),
+            predicate=lambda result: result[0] > 0,
+            timeout=5,
+            sleep_interval=0.1,
+            description="responses to arrive",
+        )
 
         (count,) = sess.execute(text(
             """
@@ -343,8 +351,8 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
         autocommit_sess.execute(text("select net.wait_until_running()"))
 
 
-def test_new_requests_get_attended_asap(sess):
-    """Check that new requests get attended as soon as possible"""
+def test_new_requests_get_attended_without_explicit_wakeup(sess, autocommit_sess):
+    """Check that new requests get attended without an explicit wakeup"""
 
     http_request(sess, text(
         """
@@ -352,24 +360,37 @@ def test_new_requests_get_attended_asap(sess):
     """
     ))
 
-    # less than a second
-    time.sleep(0.1)
+    # wait until all responses have arrived
+    wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
+            select count(*) from net._http_response;
+        """)).fetchone(),
+        predicate=lambda result: result[0] == 10,
+        timeout=10,
+        sleep_interval=0.1,
+        description="all responses to arrive",
+    )
 
-    (status_code, count) = sess.execute(text(
-        """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
 
-    assert status_code == 200
-    assert count == 10
-
-
-def test_direct_inserts_no_requests(sess):
+def test_direct_inserts_no_requests(sess, autocommit_sess):
     """
     Check that direct insertions to the net.http_request_queue doesn't
     trigger new requests
     """
+
+    # Make sure the worker has already settled into its idle wait before we
+    # insert. If a prior test left it mid-batch, its trailing WORKER_WAIT_ONE_SECOND
+    # recheck (worker.c) can pick up this test's direct insert on its own,
+    # with no net.wake() involved, and make this test flake.
+    wait_until(
+        fetch=lambda: autocommit_sess.execute(text(
+            "select state from pg_stat_activity where backend_type ilike '%pg_net%';"
+        )).fetchone(),
+        predicate=lambda result: result[0] == 'idle',
+        timeout=5,
+        sleep_interval=0.1,
+        description="pg_net worker to settle into idle before direct insert",
+    )
 
     sess.execute(text(
         """
@@ -385,10 +406,10 @@ def test_direct_inserts_no_requests(sess):
 
     sess.commit()
 
-    # wait for req
-    time.sleep(0.1)
+    # Even waiting for 5 seconds doesn't process the request
+    time.sleep(5)
 
-    # no response
+    # No response still
     (count,) = sess.execute(text(
         """
         select count(*) from net._http_response;
@@ -397,7 +418,7 @@ def test_direct_inserts_no_requests(sess):
 
     assert count == 0
 
-    # req still in queue
+    # Reqest is still in queue
     (count,) = sess.execute(text(
         """
         select count(*) from net.http_request_queue;
@@ -406,7 +427,7 @@ def test_direct_inserts_no_requests(sess):
 
     assert count == 1
 
-    # an explicit wake will make it serve requests though
+    # An explicit wake will make it serve requests though
 
     sess.execute(text(
         """
@@ -416,17 +437,16 @@ def test_direct_inserts_no_requests(sess):
 
     sess.commit()
 
-    # wait for req
-    time.sleep(0.1)
-
-    (status_code, count) = sess.execute(text(
-        """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
-
-    assert status_code == 200
-    assert count == 1
+    # wait until the response has arrived
+    wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
+            select count(*) from net._http_response;
+        """)).fetchone(),
+        predicate=lambda result: result[0] == 1,
+        timeout=10,
+        sleep_interval=0.1,
+        description="response to arrive",
+    )
 
 
 def test_processing_survives_postmaster_crash():
@@ -464,21 +484,35 @@ def test_processing_survives_postmaster_crash():
         pgdata_env = os.getenv('PGDATA')
         subprocess.run(["pg_ctl", "restart", "-D", pgdata_env])
 
-        # give it some time to finish restart
-        time.sleep(1)
+        def try_connect():
+            nonlocal engine, tmp_sess
+            try:
+                engine = create_engine("postgresql:///postgres")
+                ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
+                tmp_sess = Session(ac_engine)
+                return tmp_sess.execute(text("select 1")).fetchone()
+            except Exception:
+                return None
 
-        engine = create_engine("postgresql:///postgres")
-        ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
-        tmp_sess = Session(ac_engine)
+        # wait for postmaster to finish restarting and accept connections
+        wait_until(
+            fetch=try_connect,
+            predicate=lambda result: result is not None,
+            timeout=10,
+            sleep_interval=0.1,
+            description="postmaster to restart and accept connections",
+        )
 
-        # give it enough time to finish processing the queue
-        time.sleep(1)
-
-        (count,) = tmp_sess.execute(text(
-            """
-            select count(*) from net.http_request_queue;
-        """
-        )).fetchone()
+        # wait until the queue has finished processing
+        (count,) = wait_until(
+            fetch=lambda: tmp_sess.execute(text("""
+                select count(*) from net.http_request_queue;
+            """)).fetchone(),
+            predicate=lambda result: result[0] == 0,
+            timeout=10,
+            sleep_interval=0.1,
+            description="request queue to drain after postmaster restart",
+        )
         assert count == 0
 
         (status_code, count) = tmp_sess.execute(text(
@@ -523,13 +557,15 @@ def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
     # Wait until the worker has actually drained the queue and written all
     # responses to net._http_response. Don't assume "30 rows" - the worker
     # may pick up the queue in chunks depending on wake() coalescing.
-    for _ in range(20):
-        time.sleep(0.5)
-        (queue_count,) = sess.execute(text(
+    wait_until(
+        fetch=lambda: sess.execute(text(
             "select count(*) from net.http_request_queue;"
-        )).fetchone()
-        if queue_count == 0:
-            break
+        )).fetchone(),
+        predicate=lambda result: result[0] == 0,
+        timeout=10,
+        sleep_interval=0.5,
+        description="worker to drain the request queue",
+    )
 
     # Confirm the worker actually wrote rows, otherwise the pgstat assertion
     # below would be meaningless.
@@ -585,7 +621,16 @@ def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_ses
         autocommit_sess.execute(
             text("alter system set autovacuum_naptime = '1s';"))
         autocommit_sess.execute(text("select pg_reload_conf();"))
-        time.sleep(1)
+
+        wait_until(
+            fetch=lambda: autocommit_sess.execute(text(
+                "select current_setting('autovacuum_naptime');"
+            )).fetchone(),
+            predicate=lambda result: result[0] == '1s',
+            timeout=5,
+            sleep_interval=0.1,
+            description="autovacuum_naptime reload to propagate",
+        )
 
         # Per-table: trip the autoanalyze threshold after a handful of rows.
         # Reloptions take effect immediately; no reload required.
@@ -729,14 +774,29 @@ def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_
 
     assert pid is not None, "pg_net worker did not come back up after restart"
 
-    # wait several restart cycles; a crash loop would respawn the worker with a new pid
-    time.sleep(3)
+    # Watch for several seconds; a crash loop would respawn the worker with a
+    # new pid. Poll for the bad condition (crash or restart) so we fail as
+    # soon as it happens instead of only checking once at the end of a blind
+    # sleep; a timeout here means the worker stayed up with the same pid.
+    changed = False
+    last_row = None
+    try:
+        last_row = wait_until(
+            fetch=lambda: autocommit_sess.execute(text(
+                "select pid from pg_stat_activity where backend_type ilike '%pg_net%';"
+            )).fetchone(),
+            predicate=lambda result: result is None or result[0] != pid,
+            timeout=3,
+            sleep_interval=0.1,
+            description="pg_net worker to remain stable with the same pid",
+        )
+        changed = True
+    except AssertionError:
+        pass
 
-    row = autocommit_sess.execute(text(
-        "select pid from pg_stat_activity where backend_type ilike '%pg_net%';"
-    )).fetchone()
-    assert row is not None, "pg_net worker is down, it crashed after seeing the net schema"
-    assert row[0] == pid, "pg_net worker restarted, it's crash looping on the net schema"
+    if changed:
+        assert last_row is not None, "pg_net worker is down, it crashed after seeing the net schema"
+        assert last_row[0] == pid, "pg_net worker restarted, it's crash looping on the net schema"
 
     sess.execute(text("drop schema net;"))
     sess.commit()

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -456,7 +456,7 @@ def test_processing_survives_postmaster_crash():
     engine.dispose()
 
 
-def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
+def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess, wait_until):
     """
     Check that the worker's INSERTs into net._http_response must be reflected
     in pg_stat_user_tables. Without this, autovacuum/autoanalyze can never be
@@ -501,17 +501,16 @@ def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
     # worker's first flush attempt is normally a hit (last_flush is far in
     # the past after a long idle), but we allow generous slack here so an
     # off-by-a-tick scheduling doesn't flake the suite.
-    deadline = time.time() + 30.0
-    resp_ins = 0
-    resp_mod = 0
-    while time.time() < deadline:
-        (resp_ins, resp_mod) = autocommit_sess.execute(text("""
+    (resp_ins, resp_mod) = wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
             select n_tup_ins, n_mod_since_analyze
             from pg_stat_user_tables where relname='_http_response';
-        """)).fetchone()
-        if resp_ins > 0:
-            break
-        time.sleep(0.5)
+        """)).fetchone(),
+        predicate=lambda result: result[0] > 0,
+        timeout=30,
+        sleep_interval=0.5,
+        description="net._http_response pgstat counters to reflect worker INSERTs",
+    )
 
     assert resp_ins > 0, (
         f"net._http_response.n_tup_ins is still 0 after 30s. "
@@ -525,7 +524,7 @@ def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
     )
 
 
-def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_sess):
+def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_sess, wait_until):
     """
     Check that autoanalyze on net._http_response must fire after the worker
     writes enough rows. Without working pgstat counters, autovacuum/autoanalyze
@@ -572,16 +571,16 @@ def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_ses
     # autoanalyze worker spawn + ANALYZE on a tiny table (sub-second).
     # Real wall time on a clean rig is typically ~2-5s; the slack is to
     # absorb test-rig load and not flake.
-    deadline = time.time() + 30.0
-    autoanalyze_count = 0
-    while time.time() < deadline:
-        (autoanalyze_count,) = autocommit_sess.execute(text("""
+    (autoanalyze_count,) = wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
             select autoanalyze_count
             from pg_stat_user_tables where relname='_http_response';
-        """)).fetchone()
-        if autoanalyze_count > 0:
-            break
-        time.sleep(0.5)
+        """)).fetchone(),
+        predicate=lambda result: result[0] > 0,
+        timeout=30,
+        sleep_interval=0.5,
+        description="autoanalyze to fire on net._http_response",
+    )
 
     assert autoanalyze_count > 0, (
         "autoanalyze never fired on net._http_response within 30s. "
@@ -603,7 +602,7 @@ def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_ses
     autocommit_sess.execute(text("select pg_reload_conf();"))
 
 
-def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
+def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess, wait_until):
     """
     Check that the pg_net worker must call pgstat_report_activity() so
     its row in pg_stat_activity has a valid state column.
@@ -614,15 +613,16 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
     # Wait for the worker to drain any leftover work from previous tests
     # and settle into idle. Polling makes this robust regardless of what
     # ran before.
-    deadline = time.time() + 5.0
-    state = None
-    while time.time() < deadline:
-        (state,) = autocommit_sess.execute(text(
-            "select state from pg_stat_activity where backend_type ilike '%pg_net%';"
-        )).fetchone()
-        if state == 'idle':
-            break
-        time.sleep(0.1)
+    (state,) = wait_until(
+        fetch=lambda: autocommit_sess.execute(text(
+            "select state from pg_stat_activity where backend_type ilike '%pg_net%'"
+        )).fetchone(),
+        predicate=lambda result: result[0] == 'idle',
+        timeout=5,
+        sleep_interval=0.1,
+        description="pg_net worker to settle into idle",
+    )
+
     assert state == 'idle', (
         f"pg_net worker state expected 'idle' at rest, got {state!r}. "
         "Without pgstat_report_activity(STATE_IDLE, ...) the state column "
@@ -636,16 +636,20 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
 
     # Poll for 'active' for up to 5s. The slow request keeps the worker
     # busy for ~2s, so we have a wide observation window.
-    deadline = time.time() + 5.0
     saw_active = False
-    while time.time() < deadline:
-        (state,) = autocommit_sess.execute(text(
-            "select state from pg_stat_activity where backend_type ilike '%pg_net%';"
-        )).fetchone()
-        if state == 'active':
-            saw_active = True
-            break
-        time.sleep(0.1)
+    try:
+        wait_until(
+            fetch=lambda: autocommit_sess.execute(text(
+                "select state from pg_stat_activity where backend_type ilike '%pg_net%'"
+            )).fetchone(),
+            predicate=lambda result: result[0] == 'active',
+            timeout=5,
+            sleep_interval=0.1,
+            description="pg_net worker to be observed as active",
+        )
+        saw_active = True
+    except AssertionError:
+        pass
 
     assert saw_active, (
         "pg_net worker state was never observed as 'active' during a slow "
@@ -654,7 +658,7 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
     )
 
 
-def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_sess):
+def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_sess, wait_until):
     """
     Check that when a schema named "net" exists but the pg_net tables don't
     (e.g. another extension installed into a schema named "net"), the worker
@@ -669,16 +673,16 @@ def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_
     autocommit_sess.execute(text("select kill_worker();"))
 
     # wait for the worker to come back up (bgw_restart_time is 1 second)
-    pid = None
-    deadline = time.time() + 5.0
-    while time.time() < deadline:
-        row = autocommit_sess.execute(text(
+    (pid,) = wait_until(
+        fetch=lambda: autocommit_sess.execute(text(
             "select pid from pg_stat_activity where backend_type ilike '%pg_net%';"
-        )).fetchone()
-        if row:
-            pid = row[0]
-            break
-        time.sleep(0.1)
+        )).fetchone(),
+        predicate=lambda result: result,
+        timeout=5,
+        sleep_interval=0.1,
+        description="pg_net worker to to be back up",
+    )
+
     assert pid is not None, "pg_net worker did not come back up after restart"
 
     # wait several restart cycles; a crash loop would respawn the worker with a new pid

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -7,6 +7,7 @@ import time
 import subprocess
 import os
 
+
 def test_worker_will_not_block_drop_database(autocommit_sess):
     """the worker will not block a session doing drop database"""
 
@@ -87,7 +88,7 @@ def test_worker_will_process_queue_when_up(sess):
 
     # check requests where enqueued
     (count,) = sess.execute(text(
-    """
+        """
         select count(*) from net.http_request_queue;
     """
     )).fetchone()
@@ -117,15 +118,15 @@ def test_worker_will_process_queue_when_up(sess):
     time.sleep(1.1)
 
     (count,) = sess.execute(text(
-    """
+        """
         select count(*) from net.http_request_queue;
     """
     )).fetchone()
 
     assert count == 0
 
-    (status_code,count) = sess.execute(text(
-    """
+    (status_code, count) = sess.execute(text(
+        """
         select status_code, count(*) from net._http_response group by status_code;
     """
     )).fetchone()
@@ -266,22 +267,22 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
 
     time.sleep(0.1)
 
-    (status_code,count) = sess.execute(text(
-    """
+    (status_code, count) = sess.execute(text(
+        """
         select status_code, count(*) from net._http_response group by status_code;
     """
     )).fetchone()
 
     # at most 2 requests should have finished by now because of the low batch_size
     assert count <= 2
-    assert count > 0 # at least 1 request should be finished
+    assert count > 0  # at least 1 request should be finished
     assert status_code == 200
 
     # if we sleep for 4 seconds the whole 5 requests should be finished
     time.sleep(4)
 
-    (status_code,count) = sess.execute(text(
-    """
+    (status_code, count) = sess.execute(text(
+        """
         select status_code, count(*) from net._http_response group by status_code;
     """
     )).fetchone()
@@ -308,8 +309,8 @@ def test_new_requests_get_attended_asap(sess):
     # less than a second
     time.sleep(0.1)
 
-    (status_code,count) = sess.execute(text(
-    """
+    (status_code, count) = sess.execute(text(
+        """
         select status_code, count(*) from net._http_response group by status_code;
     """
     )).fetchone()
@@ -340,7 +341,7 @@ def test_direct_inserts_no_requests(sess):
 
     # no response
     (count,) = sess.execute(text(
-    """
+        """
         select count(*) from net._http_response;
     """
     )).fetchone()
@@ -349,7 +350,7 @@ def test_direct_inserts_no_requests(sess):
 
     # req still in queue
     (count,) = sess.execute(text(
-    """
+        """
         select count(*) from net.http_request_queue;
     """
     )).fetchone()
@@ -359,7 +360,7 @@ def test_direct_inserts_no_requests(sess):
     # an explicit wake will make it serve requests though
 
     sess.execute(text(
-    """
+        """
         select net.wake();
     """
     ))
@@ -370,7 +371,7 @@ def test_direct_inserts_no_requests(sess):
     time.sleep(0.1)
 
     (status_code, count) = sess.execute(text(
-    """
+        """
         select status_code, count(*) from net._http_response group by status_code;
     """
     )).fetchone()
@@ -399,7 +400,7 @@ def test_processing_survives_postmaster_crash():
     )).fetchone()
 
     (count,) = tmp_sess.execute(text(
-    """
+        """
         select count(*) from net.http_request_queue;
     """
     )).fetchone()
@@ -421,14 +422,14 @@ def test_processing_survives_postmaster_crash():
     time.sleep(1)
 
     (count,) = tmp_sess.execute(text(
-    """
+        """
         select count(*) from net.http_request_queue;
     """
     )).fetchone()
     assert count == 0
 
-    (status_code,count) = tmp_sess.execute(text(
-    """
+    (status_code, count) = tmp_sess.execute(text(
+        """
         select status_code, count(*) from net._http_response group by status_code;
     """
     )).fetchone()
@@ -526,7 +527,8 @@ def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_ses
     # already running on a 1s naptime by the time stats threshold is crossed.
     # autovacuum_naptime is PGC_SIGHUP (reloadable). Give the reload a moment
     # to propagate to the launcher.
-    autocommit_sess.execute(text("alter system set autovacuum_naptime = '1s';"))
+    autocommit_sess.execute(
+        text("alter system set autovacuum_naptime = '1s';"))
     autocommit_sess.execute(text("select pg_reload_conf();"))
     time.sleep(1)
 
@@ -638,7 +640,6 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
         "request. Without pgstat_report_activity(STATE_RUNNING, ...) the "
         "state column stays NULL."
     )
-
 
 
 def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_sess):

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -6,7 +6,11 @@ import time
 import subprocess
 import os
 
-from common import http_request, is_worker_up, wait_for_any_response, wait_for_extension_drop, wait_for_postgres_ready, wait_for_queue_drain, wait_for_response_count, wait_for_worker_down, wait_for_worker_state, wait_for_worker_up, wait_until, wakeup_worker
+from common import http_request, restart_worker, wait_for_any_response
+from common import wait_for_extension_drop, wait_for_postgres_ready
+from common import wait_for_queue_drain, wait_for_response_count
+from common import wait_for_worker_down, wait_for_worker_state
+from common import wait_for_worker_up, wait_until, wakeup_worker
 
 
 def test_worker_will_not_block_drop_database(autocommit_sess):
@@ -124,8 +128,7 @@ def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
     try:
         autocommit_sess.execute(
             text("alter system set pg_net.batch_size to '1';"))
-        autocommit_sess.execute(text("select net.worker_restart();"))
-        autocommit_sess.execute(text("select net.wait_until_running();"))
+        restart_worker(autocommit_sess)
 
         http_request(sess, text(
             """
@@ -146,8 +149,7 @@ def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
         sess.commit()
     finally:
         autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-        autocommit_sess.execute(text("select net.worker_restart()"))
-        autocommit_sess.execute(text("select net.wait_until_running()"))
+        restart_worker(autocommit_sess)
 
 
 def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
@@ -161,8 +163,7 @@ def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
         # net.http_request_queue in one go
         autocommit_sess.execute(
             text("alter system set pg_net.batch_size to '1';"))
-        autocommit_sess.execute(text("select net.worker_restart();"))
-        autocommit_sess.execute(text("select net.wait_until_running();"))
+        restart_worker(autocommit_sess)
 
         http_request(sess, text(
             """
@@ -186,8 +187,7 @@ def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
         assert count == 0
     finally:
         autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-        autocommit_sess.execute(text("select net.worker_restart()"))
-        autocommit_sess.execute(text("select net.wait_until_running()"))
+        restart_worker(autocommit_sess)
 
 
 def test_no_failure_on_drop_extension(sess, autocommit_sess):
@@ -231,8 +231,7 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
     try:
         autocommit_sess.execute(
             text("alter system set pg_net.batch_size to '1';"))
-        autocommit_sess.execute(text("select net.worker_restart();"))
-        autocommit_sess.execute(text("select net.wait_until_running();"))
+        restart_worker(autocommit_sess)
 
         http_request(sess, text(
             """
@@ -251,13 +250,7 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
             description="responses to arrive before first restart",
         )
 
-        # Restart the worker
-        sess.execute(text(
-            """
-            select net.worker_restart();
-            select net.wait_until_running();
-        """
-        ))
+        restart_worker(autocommit_sess)
 
         # Check that more requests are processed after a restart
         wait_until(
@@ -270,21 +263,14 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
             description="responses to arrive after first restart",
         )
 
-        # Restart again
-        sess.execute(text(
-            """
-            select net.worker_restart();
-            select net.wait_until_running();
-        """
-        ))
+        restart_worker(autocommit_sess)
 
         # And now wait until all responses have arrived
         wait_for_response_count(autocommit_sess, 5)
 
     finally:
         autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-        autocommit_sess.execute(text("select net.worker_restart()"))
-        autocommit_sess.execute(text("select net.wait_until_running()"))
+        restart_worker(autocommit_sess)
 
 
 def test_new_requests_get_attended_without_explicit_wakeup(sess, autocommit_sess):
@@ -368,8 +354,7 @@ def test_processing_survives_postmaster_crash(autocommit_sess):
         tmp_sess.execute(text("create extension if not exists pg_net;"))
 
         tmp_sess.execute(text("alter system set pg_net.batch_size to '5';"))
-        tmp_sess.execute(text("select net.worker_restart();"))
-        tmp_sess.execute(text("select net.wait_until_running();"))
+        restart_worker(tmp_sess)
 
         tmp_sess.execute(text(
             """
@@ -411,8 +396,7 @@ def test_processing_survives_postmaster_crash(autocommit_sess):
 
     finally:
         tmp_sess.execute(text("alter system reset pg_net.batch_size"))
-        tmp_sess.execute(text("select net.worker_restart()"))
-        tmp_sess.execute(text("select net.wait_until_running()"))
+        restart_worker(autocommit_sess)
 
         engine.dispose()
 

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -1,11 +1,8 @@
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
 from sqlalchemy.orm import Session
-from sqlalchemy import text
-import sqlalchemy as sa
 import time
 import subprocess
 import os
-
 from common import http_request, restart_worker, wait_for_any_response
 from common import wait_for_extension_drop, wait_for_postgres_ready
 from common import wait_for_queue_drain, wait_for_response_count

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -6,7 +6,7 @@ import time
 import subprocess
 import os
 
-from common import http_request, is_worker_up, wait_for_any_response, wait_for_extension_drop, wait_for_postgres_ready, wait_for_queue_drain, wait_for_response_count, wait_for_worker_down, wait_for_worker_state, wait_for_worker_up, wait_until
+from common import http_request, is_worker_up, wait_for_any_response, wait_for_extension_drop, wait_for_postgres_ready, wait_for_queue_drain, wait_for_response_count, wait_for_worker_down, wait_for_worker_state, wait_for_worker_up, wait_until, wakeup_worker
 
 
 def test_worker_will_not_block_drop_database(autocommit_sess):
@@ -348,14 +348,7 @@ def test_direct_inserts_no_requests(sess, autocommit_sess):
     assert count == 1
 
     # An explicit wake will make it serve requests though
-
-    sess.execute(text(
-        """
-        select net.wake();
-    """
-    ))
-
-    sess.commit()
+    wakeup_worker(sess)
 
     # wait until the response has arrived
     wait_for_response_count(autocommit_sess, 1)

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -6,7 +6,7 @@ import time
 import subprocess
 import os
 
-from common import http_request, wait_until
+from common import http_request, is_worker_up, wait_for_any_response, wait_for_extension_drop, wait_for_postgres_ready, wait_for_queue_drain, wait_for_response_count, wait_for_worker_down, wait_for_worker_state, wait_for_worker_up, wait_until
 
 
 def test_worker_will_not_block_drop_database(autocommit_sess):
@@ -73,15 +73,7 @@ def test_worker_will_process_queue_when_up(sess, autocommit_sess):
     assert killed == True
 
     # Wait for background worker to go down
-    wait_until(
-        fetch=lambda: autocommit_sess.execute(text("""
-            select is_worker_up();
-        """)).fetchone(),
-        predicate=lambda result: not result[0],
-        timeout=5,
-        sleep_interval=0.1,
-        description="background worker to go down",
-    )
+    wait_for_worker_down(autocommit_sess)
 
     # Make a request while the worker is down
     http_request(sess, text(
@@ -114,37 +106,13 @@ def test_worker_will_process_queue_when_up(sess, autocommit_sess):
     # It's critical to use autocommit_sess to see a new snapshot
     # on each retry in wait_until, otherwise it might keep reading
     # stale data and fail with a timeout.
-    wait_until(
-        fetch=lambda: autocommit_sess.execute(text("""
-            select is_worker_up();
-        """)).fetchone(),
-        predicate=lambda result: result[0],
-        timeout=5,
-        sleep_interval=0.1,
-        description="background worker to be up",
-    )
+    wait_for_worker_up(autocommit_sess)
 
-    # Wait until new requests are in flight
-    wait_until(
-        fetch=lambda: autocommit_sess.execute(text("""
-            select count(*) from net.http_request_queue;
-        """)).fetchone(),
-        predicate=lambda result: result[0] == 0,
-        timeout=5,
-        sleep_interval=0.1,
-        description="request queue to drain",
-    )
+    # Wait for request queue to drain
+    wait_for_queue_drain(autocommit_sess)
 
     # Wait until all responses have arrived
-    wait_until(
-        fetch=lambda: autocommit_sess.execute(text("""
-            select status_code, count(*) from net._http_response group by status_code;
-        """)).fetchone(),
-        predicate=lambda result: result[0] == 200 and result[1] == 10,
-        timeout=5,
-        sleep_interval=0.1,
-        description="responses to arrive",
-    )
+    wait_for_response_count(autocommit_sess, 10)
 
 
 def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
@@ -166,15 +134,7 @@ def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
         ))
 
         # Wait until responses have started arriving
-        wait_until(
-            fetch=lambda: autocommit_sess.execute(text("""
-                select count(*) from net._http_response;
-            """)).fetchone(),
-            predicate=lambda result: result[0] > 0,
-            timeout=5,
-            sleep_interval=0.1,
-            description="responses to arrive",
-        )
+        wait_for_any_response(autocommit_sess)
 
         (count,) = sess.execute(text(
             """
@@ -243,15 +203,7 @@ def test_no_failure_on_drop_extension(sess, autocommit_sess):
     ))
 
     # Wait until responses have started arriving
-    wait_until(
-        fetch=lambda: autocommit_sess.execute(text("""
-            select count(*) from net._http_response;
-        """)).fetchone(),
-        predicate=lambda result: result[0] > 0,
-        timeout=5,
-        sleep_interval=0.1,
-        description="responses to arrive",
-    )
+    wait_for_any_response(autocommit_sess)
 
     sess.execute(text("""
         drop extension pg_net cascade;
@@ -260,15 +212,7 @@ def test_no_failure_on_drop_extension(sess, autocommit_sess):
     sess.commit()
 
     # wait until the extension is fully gone
-    wait_until(
-        fetch=lambda: autocommit_sess.execute(text("""
-            select count(*) from pg_extension where extname = 'pg_net';
-        """)).fetchone(),
-        predicate=lambda result: result[0] == 0,
-        timeout=5,
-        sleep_interval=0.1,
-        description="extension to be dropped",
-    )
+    wait_for_extension_drop(autocommit_sess)
 
     # The background worker should not have crash even after dropping the extension
     (up,) = sess.execute(text("""
@@ -335,15 +279,7 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
         ))
 
         # And now wait until all responses have arrived
-        wait_until(
-            fetch=lambda: autocommit_sess.execute(text("""
-                select count(*) from net._http_response;
-            """)).fetchone(),
-            predicate=lambda result: result[0] == 5,
-            timeout=10,
-            sleep_interval=0.1,
-            description="responses to arrive after second restart",
-        )
+        wait_for_response_count(autocommit_sess, 5)
 
     finally:
         autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
@@ -361,15 +297,7 @@ def test_new_requests_get_attended_without_explicit_wakeup(sess, autocommit_sess
     ))
 
     # wait until all responses have arrived
-    wait_until(
-        fetch=lambda: autocommit_sess.execute(text("""
-            select count(*) from net._http_response;
-        """)).fetchone(),
-        predicate=lambda result: result[0] == 10,
-        timeout=10,
-        sleep_interval=0.1,
-        description="all responses to arrive",
-    )
+    wait_for_response_count(autocommit_sess, 10)
 
 
 def test_direct_inserts_no_requests(sess, autocommit_sess):
@@ -382,15 +310,7 @@ def test_direct_inserts_no_requests(sess, autocommit_sess):
     # insert. If a prior test left it mid-batch, its trailing WORKER_WAIT_ONE_SECOND
     # recheck (worker.c) can pick up this test's direct insert on its own,
     # with no net.wake() involved, and make this test flake.
-    wait_until(
-        fetch=lambda: autocommit_sess.execute(text(
-            "select state from pg_stat_activity where backend_type ilike '%pg_net%';"
-        )).fetchone(),
-        predicate=lambda result: result[0] == 'idle',
-        timeout=5,
-        sleep_interval=0.1,
-        description="pg_net worker to settle into idle before direct insert",
-    )
+    wait_for_worker_state(autocommit_sess, 'idle')
 
     sess.execute(text(
         """
@@ -438,18 +358,10 @@ def test_direct_inserts_no_requests(sess, autocommit_sess):
     sess.commit()
 
     # wait until the response has arrived
-    wait_until(
-        fetch=lambda: autocommit_sess.execute(text("""
-            select count(*) from net._http_response;
-        """)).fetchone(),
-        predicate=lambda result: result[0] == 1,
-        timeout=10,
-        sleep_interval=0.1,
-        description="response to arrive",
-    )
+    wait_for_response_count(autocommit_sess, 1)
 
 
-def test_processing_survives_postmaster_crash():
+def test_processing_survives_postmaster_crash(autocommit_sess):
     """
     Check that the queue will continue processing even when a postmaster
     crash or restart happens
@@ -484,36 +396,16 @@ def test_processing_survives_postmaster_crash():
         pgdata_env = os.getenv('PGDATA')
         subprocess.run(["pg_ctl", "restart", "-D", pgdata_env])
 
-        def try_connect():
-            nonlocal engine, tmp_sess
-            try:
-                engine = create_engine("postgresql:///postgres")
-                ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
-                tmp_sess = Session(ac_engine)
-                return tmp_sess.execute(text("select 1")).fetchone()
-            except Exception:
-                return None
-
         # wait for postmaster to finish restarting and accept connections
-        wait_until(
-            fetch=try_connect,
-            predicate=lambda result: result is not None,
-            timeout=10,
-            sleep_interval=0.1,
-            description="postmaster to restart and accept connections",
-        )
+        wait_for_postgres_ready(engine, tmp_sess)
+
+        # Recreate engine and session after restart
+        engine = create_engine("postgresql:///postgres")
+        ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
+        tmp_sess = Session(ac_engine)
 
         # wait until the queue has finished processing
-        (count,) = wait_until(
-            fetch=lambda: tmp_sess.execute(text("""
-                select count(*) from net.http_request_queue;
-            """)).fetchone(),
-            predicate=lambda result: result[0] == 0,
-            timeout=10,
-            sleep_interval=0.1,
-            description="request queue to drain after postmaster restart",
-        )
-        assert count == 0
+        wait_for_queue_drain(autocommit_sess)
 
         (status_code, count) = tmp_sess.execute(text(
             """
@@ -702,21 +594,7 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
     # Wait for the worker to drain any leftover work from previous tests
     # and settle into idle. Polling makes this robust regardless of what
     # ran before.
-    (state,) = wait_until(
-        fetch=lambda: autocommit_sess.execute(text(
-            "select state from pg_stat_activity where backend_type ilike '%pg_net%'"
-        )).fetchone(),
-        predicate=lambda result: result[0] == 'idle',
-        timeout=5,
-        sleep_interval=0.1,
-        description="pg_net worker to settle into idle",
-    )
-
-    assert state == 'idle', (
-        f"pg_net worker state expected 'idle' at rest, got {state!r}. "
-        "Without pgstat_report_activity(STATE_IDLE, ...) the state column "
-        "stays NULL."
-    )
+    wait_for_worker_state(autocommit_sess, 'idle')
 
     # Fire a slow request so the worker stays active long enough to observe.
     http_request(sess, text("""
@@ -727,15 +605,7 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
     # busy for ~2s, so we have a wide observation window.
     saw_active = False
     try:
-        wait_until(
-            fetch=lambda: autocommit_sess.execute(text(
-                "select state from pg_stat_activity where backend_type ilike '%pg_net%'"
-            )).fetchone(),
-            predicate=lambda result: result[0] == 'active',
-            timeout=5,
-            sleep_interval=0.1,
-            description="pg_net worker to be observed as active",
-        )
+        wait_for_worker_state(autocommit_sess, 'active')
         saw_active = True
     except AssertionError:
         pass

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm import Session
 import time
 import subprocess
 import os
-from common import http_request, restart_worker, wait_for_any_response
+from common import http_request, http_requests, restart_worker, wait_for_any_response
 from common import wait_for_extension_drop, wait_for_postgres_ready
 from common import wait_for_queue_drain, wait_for_response_count
 from common import wait_for_worker_down, wait_for_worker_state
@@ -77,7 +77,7 @@ def test_worker_will_process_queue_when_up(sess, autocommit_sess):
     wait_for_worker_down(autocommit_sess)
 
     # Make a request while the worker is down
-    http_request(sess, text(
+    http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
     """
@@ -127,7 +127,7 @@ def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
             text("alter system set pg_net.batch_size to '1';"))
         restart_worker(autocommit_sess)
 
-        http_request(sess, text(
+        http_requests(sess, text(
             """
             select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
         """
@@ -162,7 +162,7 @@ def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
             text("alter system set pg_net.batch_size to '1';"))
         restart_worker(autocommit_sess)
 
-        http_request(sess, text(
+        http_requests(sess, text(
             """
             select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
         """
@@ -193,7 +193,7 @@ def test_no_failure_on_drop_extension(sess, autocommit_sess):
     wait and not crash the worker
     """
 
-    http_request(sess, text(
+    http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200&delay=2') from generate_series(1,10);
     """
@@ -230,7 +230,7 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
             text("alter system set pg_net.batch_size to '1';"))
         restart_worker(autocommit_sess)
 
-        http_request(sess, text(
+        http_requests(sess, text(
             """
             select net.http_get('http://localhost:8080/pathological?status=200&delay=1') from generate_series(1,5);
         """
@@ -273,7 +273,7 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
 def test_new_requests_get_attended_without_explicit_wakeup(sess, autocommit_sess):
     """Check that new requests get attended without an explicit wakeup"""
 
-    http_request(sess, text(
+    http_requests(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
     """
@@ -415,7 +415,7 @@ def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
     ))
 
     # Drive a batch of requests through the worker.
-    http_request(sess, text("""
+    http_requests(sess, text("""
         select net.http_get('http://localhost:8080/pathological?status=200')
         from generate_series(1,30);
     """))
@@ -514,7 +514,7 @@ def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_ses
         ))
 
         # Drive 30 inserts through the worker. 30 is well above the threshold (10).
-        http_request(sess, text("""
+        http_requests(sess, text("""
             select net.http_get('http://localhost:8080/pathological?status=200')
             from generate_series(1,30);
         """))
@@ -571,7 +571,7 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
     wait_for_worker_state(autocommit_sess, 'idle')
 
     # Fire a slow request so the worker stays active long enough to observe.
-    http_request(sess, text("""
+    http_requests(sess, text("""
         select net.http_get('http://localhost:8080/pathological?status=200&delay=2');
     """))
 

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -100,7 +100,7 @@ def test_worker_will_process_queue_when_up(sess, autocommit_sess):
 
     # Check that worker is still down. Note that this is a bit racy
     # as there is no guarantee that worker hasn't come back up at this
-    # time, but in practice this rarely fails because worker takes 2 
+    # time, but in practice this rarely fails because worker takes 2
     # seconds before coming back up, which is more than enough time
     # to reach here.
     (worker_is_up,) = sess.execute(text("""
@@ -154,7 +154,8 @@ def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
     """
 
     try:
-        autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
+        autocommit_sess.execute(
+            text("alter system set pg_net.batch_size to '1';"))
         autocommit_sess.execute(text("select net.worker_restart();"))
         autocommit_sess.execute(text("select net.wait_until_running();"))
 
@@ -169,7 +170,7 @@ def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
 
         (count,) = sess.execute(text(
             """
-            WITH deleted AS (DELETE FROM net.http_request_queue RETURNING *) SELECT count(*) FROM deleted;
+            with deleted as (delete from net.http_request_queue returning *) select count(*) from deleted;
         """
         )).fetchone()
         assert count > 1
@@ -190,7 +191,8 @@ def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
     try:
         # ensure the worker will be processing the queue 1 by 1 (slowly) so it doesn't clear the whole
         # net.http_request_queue in one go
-        autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
+        autocommit_sess.execute(
+            text("alter system set pg_net.batch_size to '1';"))
         autocommit_sess.execute(text("select net.worker_restart();"))
         autocommit_sess.execute(text("select net.wait_until_running();"))
 
@@ -220,20 +222,28 @@ def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
         autocommit_sess.execute(text("select net.wait_until_running()"))
 
 
-def test_no_failure_on_drop_extension(sess):
+def test_no_failure_on_drop_extension(sess, autocommit_sess):
     """
     Check that while waiting for a slow request, a drop extension should
     wait and not crash the worker
     """
 
-    (request_id,) = http_request(sess, text("""
-        select net.http_get(url := 'http://localhost:8080/pathological?status=200&delay=2');
-    """))
+    http_request(sess, text(
+        """
+        select net.http_get('http://localhost:8080/pathological?status=200&delay=2') from generate_series(1,10);
+    """
+    ))
 
-    assert request_id == 1
-
-    # wait until processing
-    time.sleep(1)
+    # Wait until responses have started arriving
+    wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
+            select count(*) from net._http_response;
+        """)).fetchone(),
+        predicate=lambda result: result[0] > 0,
+        timeout=5,
+        sleep_interval=0.1,
+        description="responses to arrive",
+    )
 
     sess.execute(text("""
         drop extension pg_net cascade;
@@ -241,9 +251,18 @@ def test_no_failure_on_drop_extension(sess):
 
     sess.commit()
 
-    # wait until request is finished
-    time.sleep(3)
+    # wait until the extension is fully gone
+    wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
+            select count(*) from pg_extension where extname = 'pg_net';
+        """)).fetchone(),
+        predicate=lambda result: result[0] == 0,
+        timeout=5,
+        sleep_interval=0.1,
+        description="extension to be dropped",
+    )
 
+    # The background worker should not have crash even after dropping the extension
     (up,) = sess.execute(text("""
         select is_worker_up();
     """)).fetchone()
@@ -258,18 +277,29 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
     """
 
     try:
-        autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
+        autocommit_sess.execute(
+            text("alter system set pg_net.batch_size to '1';"))
         autocommit_sess.execute(text("select net.worker_restart();"))
         autocommit_sess.execute(text("select net.wait_until_running();"))
 
         http_request(sess, text(
             """
-            select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,5);
+            select net.http_get('http://localhost:8080/pathological?status=200&delay=1') from generate_series(1,5);
         """
         ))
 
-        # one restart will likely keep the worker awake since the wake signal could still be on, so do two restarts
-        # to ensure the wake signal is cleared
+        # Wait until responses have started arriving
+        (processed,) = wait_until(
+            fetch=lambda: autocommit_sess.execute(text("""
+                select count(*) from net._http_response;
+            """)).fetchone(),
+            predicate=lambda result: result[0] > 0,
+            timeout=5,
+            sleep_interval=0.1,
+            description="responses to arrive before first restart",
+        )
+
+        # Restart the worker
         sess.execute(text(
             """
             select net.worker_restart();
@@ -277,8 +307,18 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
         """
         ))
 
-        time.sleep(0.1)
+        # Check that more requests are processed after a restart
+        wait_until(
+            fetch=lambda: autocommit_sess.execute(text("""
+                select count(*) from net._http_response;
+            """)).fetchone(),
+            predicate=lambda result: result[0] >= processed,
+            timeout=5,
+            sleep_interval=0.1,
+            description="responses to arrive after first restart",
+        )
 
+        # Restart again
         sess.execute(text(
             """
             select net.worker_restart();
@@ -286,30 +326,16 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
         """
         ))
 
-        time.sleep(0.1)
-
-        (status_code, count) = sess.execute(text(
-            """
-            select status_code, count(*) from net._http_response group by status_code;
-        """
-        )).fetchone()
-
-        # at most 2 requests should have finished by now because of the low batch_size
-        assert count <= 2
-        assert count > 0  # at least 1 request should be finished
-        assert status_code == 200
-
-        # if we sleep for 4 seconds the whole 5 requests should be finished
-        time.sleep(4)
-
-        (status_code, count) = sess.execute(text(
-            """
-            select status_code, count(*) from net._http_response group by status_code;
-        """
-        )).fetchone()
-
-        assert status_code == 200
-        assert count == 5
+        # And now wait until all responses have arrived
+        wait_until(
+            fetch=lambda: autocommit_sess.execute(text("""
+                select count(*) from net._http_response;
+            """)).fetchone(),
+            predicate=lambda result: result[0] == 5,
+            timeout=10,
+            sleep_interval=0.1,
+            description="responses to arrive after second restart",
+        )
 
     finally:
         autocommit_sess.execute(text("alter system reset pg_net.batch_size"))

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -2,10 +2,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 from sqlalchemy import text
 import sqlalchemy as sa
-import pytest
 import time
 import subprocess
 import os
+
+from common import http_request
 
 
 def test_worker_will_not_block_drop_database(autocommit_sess):
@@ -81,13 +82,11 @@ def test_worker_will_process_queue_when_up(sess):
     assert up is not None
     assert up == False
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
     """
-    )).fetchone()
-
-    sess.commit()
+    ))
 
     # check requests where enqueued
     (count,) = sess.execute(text(
@@ -148,13 +147,11 @@ def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
     autocommit_sess.execute(text("select net.worker_restart();"))
     autocommit_sess.execute(text("select net.wait_until_running();"))
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
     """
     ))
-
-    sess.commit()
 
     # leave time for some processing
     time.sleep(0.1)
@@ -185,12 +182,11 @@ def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
     autocommit_sess.execute(text("select net.worker_restart();"))
     autocommit_sess.execute(text("select net.wait_until_running();"))
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
     """
     ))
-    sess.commit()
 
     # truncate succeeds fast, despite the worker still processing the queue 1 by 1
     sess.execute(text(
@@ -218,12 +214,11 @@ def test_no_failure_on_drop_extension(sess):
     wait and not crash the worker
     """
 
-    (request_id,) = sess.execute(text("""
+    (request_id,) = http_request(sess, text("""
         select net.http_get(url := 'http://localhost:8080/pathological?status=200&delay=2');
-    """)).fetchone()
-    assert request_id == 1
+    """))
 
-    sess.commit()
+    assert request_id == 1
 
     # wait until processing
     time.sleep(1)
@@ -254,13 +249,11 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
     autocommit_sess.execute(text("select net.worker_restart();"))
     autocommit_sess.execute(text("select net.wait_until_running();"))
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,5);
     """
     ))
-
-    sess.commit()
 
     # one restart will likely keep the worker awake since the wake signal could still be on, so do two restarts
     # to ensure the wake signal is cleared
@@ -313,13 +306,11 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
 def test_new_requests_get_attended_asap(sess):
     """Check that new requests get attended as soon as possible"""
 
-    sess.execute(text(
+    http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
     """
     ))
-
-    sess.commit()
 
     # less than a second
     time.sleep(0.1)
@@ -482,11 +473,10 @@ def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
     ))
 
     # Drive a batch of requests through the worker.
-    sess.execute(text("""
+    http_request(sess, text("""
         select net.http_get('http://localhost:8080/pathological?status=200')
         from generate_series(1,30);
     """))
-    sess.commit()
 
     # Wait until the worker has actually drained the queue and written all
     # responses to net._http_response. Don't assume "30 rows" - the worker
@@ -571,11 +561,10 @@ def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_ses
     ))
 
     # Drive 30 inserts through the worker. 30 is well above the threshold (10).
-    sess.execute(text("""
+    http_request(sess, text("""
         select net.http_get('http://localhost:8080/pathological?status=200')
         from generate_series(1,30);
     """))
-    sess.commit()
 
     # 30s budget covers worst-case worker pgstat flush (PGSTAT_MIN_INTERVAL
     # = 1s slack) + worst-case launcher cycle (autovacuum_max_workers=3,
@@ -641,10 +630,9 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
     )
 
     # Fire a slow request so the worker stays active long enough to observe.
-    sess.execute(text("""
+    http_request(sess, text("""
         select net.http_get('http://localhost:8080/pathological?status=200&delay=2');
     """))
-    sess.commit()
 
     # Poll for 'active' for up to 5s. The slow request keeps the worker
     # busy for ~2s, so we have a wide observation window.

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -80,7 +80,7 @@ def test_worker_will_process_queue_when_up(sess, autocommit_sess):
         predicate=lambda result: not result[0],
         timeout=5,
         sleep_interval=0.1,
-        description="background worker to be down",
+        description="background worker to go down",
     )
 
     # Make a request while the worker is down
@@ -143,7 +143,7 @@ def test_worker_will_process_queue_when_up(sess, autocommit_sess):
         predicate=lambda result: result[0] == 200 and result[1] == 10,
         timeout=5,
         sleep_interval=0.1,
-        description="request queue to drain",
+        description="responses to arrive",
     )
 
 
@@ -153,31 +153,32 @@ def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
     processing them
     """
 
-    autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
-    autocommit_sess.execute(text("select net.worker_restart();"))
-    autocommit_sess.execute(text("select net.wait_until_running();"))
+    try:
+        autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
+        autocommit_sess.execute(text("select net.worker_restart();"))
+        autocommit_sess.execute(text("select net.wait_until_running();"))
 
-    http_request(sess, text(
+        http_request(sess, text(
+            """
+            select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
         """
-        select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
-    """
-    ))
+        ))
 
-    # leave time for some processing
-    time.sleep(0.1)
+        # leave time for some processing
+        time.sleep(0.1)
 
-    (count,) = sess.execute(text(
+        (count,) = sess.execute(text(
+            """
+            WITH deleted AS (DELETE FROM net.http_request_queue RETURNING *) SELECT count(*) FROM deleted;
         """
-        WITH deleted AS (DELETE FROM net.http_request_queue RETURNING *) SELECT count(*) FROM deleted;
-    """
-    )).fetchone()
-    assert count > 1
+        )).fetchone()
+        assert count > 1
 
-    sess.commit()
-
-    autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+        sess.commit()
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
+        autocommit_sess.execute(text("select net.worker_restart()"))
+        autocommit_sess.execute(text("select net.wait_until_running()"))
 
 
 def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
@@ -186,36 +187,37 @@ def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
     is done processing all requests
     """
 
-    # ensure the worker will be processing the queue 1 by 1 (slowly) so it doesn't clear the whole
-    # net.http_request_queue in one go
-    autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
-    autocommit_sess.execute(text("select net.worker_restart();"))
-    autocommit_sess.execute(text("select net.wait_until_running();"))
+    try:
+        # ensure the worker will be processing the queue 1 by 1 (slowly) so it doesn't clear the whole
+        # net.http_request_queue in one go
+        autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
+        autocommit_sess.execute(text("select net.worker_restart();"))
+        autocommit_sess.execute(text("select net.wait_until_running();"))
 
-    http_request(sess, text(
+        http_request(sess, text(
+            """
+            select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
         """
-        select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
-    """
-    ))
+        ))
 
-    # truncate succeeds fast, despite the worker still processing the queue 1 by 1
-    sess.execute(text(
+        # truncate succeeds fast, despite the worker still processing the queue 1 by 1
+        sess.execute(text(
+            """
+            truncate net.http_request_queue;
         """
-        truncate net.http_request_queue;
-    """
-    ))
+        ))
 
-    # now the queue will be empty
-    (count,) = sess.execute(text(
+        # now the queue will be empty
+        (count,) = sess.execute(text(
+            """
+            select count(*) from net.http_request_queue;
         """
-        select count(*) from net.http_request_queue;
-    """
-    )).fetchone()
-    assert count == 0
-
-    autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+        )).fetchone()
+        assert count == 0
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
+        autocommit_sess.execute(text("select net.worker_restart()"))
+        autocommit_sess.execute(text("select net.wait_until_running()"))
 
 
 def test_no_failure_on_drop_extension(sess):
@@ -255,62 +257,64 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
     it will pick up the remaining requests
     """
 
-    autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
-    autocommit_sess.execute(text("select net.worker_restart();"))
-    autocommit_sess.execute(text("select net.wait_until_running();"))
+    try:
+        autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
+        autocommit_sess.execute(text("select net.worker_restart();"))
+        autocommit_sess.execute(text("select net.wait_until_running();"))
 
-    http_request(sess, text(
+        http_request(sess, text(
+            """
+            select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,5);
         """
-        select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,5);
-    """
-    ))
+        ))
 
-    # one restart will likely keep the worker awake since the wake signal could still be on, so do two restarts
-    # to ensure the wake signal is cleared
-    sess.execute(text(
+        # one restart will likely keep the worker awake since the wake signal could still be on, so do two restarts
+        # to ensure the wake signal is cleared
+        sess.execute(text(
+            """
+            select net.worker_restart();
+            select net.wait_until_running();
         """
-        select net.worker_restart();
-        select net.wait_until_running();
-    """
-    ))
+        ))
 
-    time.sleep(0.1)
+        time.sleep(0.1)
 
-    sess.execute(text(
+        sess.execute(text(
+            """
+            select net.worker_restart();
+            select net.wait_until_running();
         """
-        select net.worker_restart();
-        select net.wait_until_running();
-    """
-    ))
+        ))
 
-    time.sleep(0.1)
+        time.sleep(0.1)
 
-    (status_code, count) = sess.execute(text(
+        (status_code, count) = sess.execute(text(
+            """
+            select status_code, count(*) from net._http_response group by status_code;
         """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
+        )).fetchone()
 
-    # at most 2 requests should have finished by now because of the low batch_size
-    assert count <= 2
-    assert count > 0  # at least 1 request should be finished
-    assert status_code == 200
+        # at most 2 requests should have finished by now because of the low batch_size
+        assert count <= 2
+        assert count > 0  # at least 1 request should be finished
+        assert status_code == 200
 
-    # if we sleep for 4 seconds the whole 5 requests should be finished
-    time.sleep(4)
+        # if we sleep for 4 seconds the whole 5 requests should be finished
+        time.sleep(4)
 
-    (status_code, count) = sess.execute(text(
+        (status_code, count) = sess.execute(text(
+            """
+            select status_code, count(*) from net._http_response group by status_code;
         """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
+        )).fetchone()
 
-    assert status_code == 200
-    assert count == 5
+        assert status_code == 200
+        assert count == 5
 
-    autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
-    autocommit_sess.execute(text("select net.worker_restart()"))
-    autocommit_sess.execute(text("select net.wait_until_running()"))
+    finally:
+        autocommit_sess.execute(text("alter system reset pg_net.batch_size"))
+        autocommit_sess.execute(text("select net.worker_restart()"))
+        autocommit_sess.execute(text("select net.wait_until_running()"))
 
 
 def test_new_requests_get_attended_asap(sess):
@@ -409,61 +413,63 @@ def test_processing_survives_postmaster_crash():
     ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
     tmp_sess = Session(ac_engine)
 
-    tmp_sess.execute(text("create extension if not exists pg_net;"))
+    try:
+        tmp_sess.execute(text("create extension if not exists pg_net;"))
 
-    tmp_sess.execute(text("alter system set pg_net.batch_size to '5';"))
-    tmp_sess.execute(text("select net.worker_restart();"))
-    tmp_sess.execute(text("select net.wait_until_running();"))
+        tmp_sess.execute(text("alter system set pg_net.batch_size to '5';"))
+        tmp_sess.execute(text("select net.worker_restart();"))
+        tmp_sess.execute(text("select net.wait_until_running();"))
 
-    tmp_sess.execute(text(
+        tmp_sess.execute(text(
+            """
+            select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
         """
-        select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
-    """
-    )).fetchone()
+        )).fetchone()
 
-    (count,) = tmp_sess.execute(text(
+        (count,) = tmp_sess.execute(text(
+            """
+            select count(*) from net.http_request_queue;
         """
-        select count(*) from net.http_request_queue;
-    """
-    )).fetchone()
-    assert count == 10
+        )).fetchone()
+        assert count == 10
 
-    engine.dispose()
+        engine.dispose()
 
-    pgdata_env = os.getenv('PGDATA')
-    subprocess.run(["pg_ctl", "restart", "-D", pgdata_env])
+        pgdata_env = os.getenv('PGDATA')
+        subprocess.run(["pg_ctl", "restart", "-D", pgdata_env])
 
-    # give it some time to finish restart
-    time.sleep(1)
+        # give it some time to finish restart
+        time.sleep(1)
 
-    engine = create_engine("postgresql:///postgres")
-    ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
-    tmp_sess = Session(ac_engine)
+        engine = create_engine("postgresql:///postgres")
+        ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
+        tmp_sess = Session(ac_engine)
 
-    # give it enough time to finish processing the queue
-    time.sleep(1)
+        # give it enough time to finish processing the queue
+        time.sleep(1)
 
-    (count,) = tmp_sess.execute(text(
+        (count,) = tmp_sess.execute(text(
+            """
+            select count(*) from net.http_request_queue;
         """
-        select count(*) from net.http_request_queue;
-    """
-    )).fetchone()
-    assert count == 0
+        )).fetchone()
+        assert count == 0
 
-    (status_code, count) = tmp_sess.execute(text(
+        (status_code, count) = tmp_sess.execute(text(
+            """
+            select status_code, count(*) from net._http_response group by status_code;
         """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
+        )).fetchone()
 
-    assert status_code == 200
-    assert count == 10
+        assert status_code == 200
+        assert count == 10
 
-    tmp_sess.execute(text("alter system reset pg_net.batch_size"))
-    tmp_sess.execute(text("select net.worker_restart()"))
-    tmp_sess.execute(text("select net.wait_until_running()"))
+    finally:
+        tmp_sess.execute(text("alter system reset pg_net.batch_size"))
+        tmp_sess.execute(text("select net.worker_restart()"))
+        tmp_sess.execute(text("select net.wait_until_running()"))
 
-    engine.dispose()
+        engine.dispose()
 
 
 def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
@@ -542,74 +548,76 @@ def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_ses
     seen on production (slow expiry DELETEs from a bloated index).
     """
 
-    # Make sure the worker is fully up before we start.
-    autocommit_sess.execute(text("select net.wait_until_running();"))
+    try:
+        # Make sure the worker is fully up before we start.
+        autocommit_sess.execute(text("select net.wait_until_running();"))
 
-    # Make autovacuum eager *before* generating traffic so the launcher is
-    # already running on a 1s naptime by the time stats threshold is crossed.
-    # autovacuum_naptime is PGC_SIGHUP (reloadable). Give the reload a moment
-    # to propagate to the launcher.
-    autocommit_sess.execute(
-        text("alter system set autovacuum_naptime = '1s';"))
-    autocommit_sess.execute(text("select pg_reload_conf();"))
-    time.sleep(1)
+        # Make autovacuum eager *before* generating traffic so the launcher is
+        # already running on a 1s naptime by the time stats threshold is crossed.
+        # autovacuum_naptime is PGC_SIGHUP (reloadable). Give the reload a moment
+        # to propagate to the launcher.
+        autocommit_sess.execute(
+            text("alter system set autovacuum_naptime = '1s';"))
+        autocommit_sess.execute(text("select pg_reload_conf();"))
+        time.sleep(1)
 
-    # Per-table: trip the autoanalyze threshold after a handful of rows.
-    # Reloptions take effect immediately; no reload required.
-    autocommit_sess.execute(text("""
-        alter table net._http_response set (
-            autovacuum_analyze_threshold = 10,
-            autovacuum_analyze_scale_factor = 0,
-            autovacuum_vacuum_threshold = 10,
-            autovacuum_vacuum_scale_factor = 0
-        );
-    """))
+        # Per-table: trip the autoanalyze threshold after a handful of rows.
+        # Reloptions take effect immediately; no reload required.
+        autocommit_sess.execute(text("""
+            alter table net._http_response set (
+                autovacuum_analyze_threshold = 10,
+                autovacuum_analyze_scale_factor = 0,
+                autovacuum_vacuum_threshold = 10,
+                autovacuum_vacuum_scale_factor = 0
+            );
+        """))
 
-    autocommit_sess.execute(text(
-        "select pg_stat_reset_single_table_counters('net._http_response'::regclass);"
-    ))
+        autocommit_sess.execute(text(
+            "select pg_stat_reset_single_table_counters('net._http_response'::regclass);"
+        ))
 
-    # Drive 30 inserts through the worker. 30 is well above the threshold (10).
-    http_request(sess, text("""
-        select net.http_get('http://localhost:8080/pathological?status=200')
-        from generate_series(1,30);
-    """))
+        # Drive 30 inserts through the worker. 30 is well above the threshold (10).
+        http_request(sess, text("""
+            select net.http_get('http://localhost:8080/pathological?status=200')
+            from generate_series(1,30);
+        """))
 
-    # 30s budget covers worst-case worker pgstat flush (PGSTAT_MIN_INTERVAL
-    # = 1s slack) + worst-case launcher cycle (autovacuum_max_workers=3,
-    # 3 databases at 1s naptime each ~= 3s/cycle, with 2-3 cycle slack) +
-    # autoanalyze worker spawn + ANALYZE on a tiny table (sub-second).
-    # Real wall time on a clean rig is typically ~2-5s; the slack is to
-    # absorb test-rig load and not flake.
-    (autoanalyze_count,) = wait_until(
-        fetch=lambda: autocommit_sess.execute(text("""
-            select autoanalyze_count
-            from pg_stat_user_tables where relname='_http_response';
-        """)).fetchone(),
-        predicate=lambda result: result[0] > 0,
-        timeout=30,
-        sleep_interval=0.5,
-        description="autoanalyze to fire on net._http_response",
-    )
+        # 30s budget covers worst-case worker pgstat flush (PGSTAT_MIN_INTERVAL
+        # = 1s slack) + worst-case launcher cycle (autovacuum_max_workers=3,
+        # 3 databases at 1s naptime each ~= 3s/cycle, with 2-3 cycle slack) +
+        # autoanalyze worker spawn + ANALYZE on a tiny table (sub-second).
+        # Real wall time on a clean rig is typically ~2-5s; the slack is to
+        # absorb test-rig load and not flake.
+        (autoanalyze_count,) = wait_until(
+            fetch=lambda: autocommit_sess.execute(text("""
+                select autoanalyze_count
+                from pg_stat_user_tables where relname='_http_response';
+            """)).fetchone(),
+            predicate=lambda result: result[0] > 0,
+            timeout=30,
+            sleep_interval=0.5,
+            description="autoanalyze to fire on net._http_response",
+        )
 
-    assert autoanalyze_count > 0, (
-        "autoanalyze never fired on net._http_response within 30s. "
-        "Worker writes are not making pgstat threshold visible to the "
-        "autovacuum launcher - the customer-facing symptom (silent bloat) "
-        "would manifest in production."
-    )
+        assert autoanalyze_count > 0, (
+            "autoanalyze never fired on net._http_response within 30s. "
+            "Worker writes are not making pgstat threshold visible to the "
+            "autovacuum launcher - the customer-facing symptom (silent bloat) "
+            "would manifest in production."
+        )
 
-    # Cleanup: restore defaults so we don't bleed into other tests.
-    autocommit_sess.execute(text("""
-        alter table net._http_response reset (
-            autovacuum_analyze_threshold,
-            autovacuum_analyze_scale_factor,
-            autovacuum_vacuum_threshold,
-            autovacuum_vacuum_scale_factor
-        );
-    """))
-    autocommit_sess.execute(text("alter system reset autovacuum_naptime;"))
-    autocommit_sess.execute(text("select pg_reload_conf();"))
+    finally:
+        # Cleanup: restore defaults so we don't bleed into other tests.
+        autocommit_sess.execute(text("""
+            alter table net._http_response reset (
+                autovacuum_analyze_threshold,
+                autovacuum_analyze_scale_factor,
+                autovacuum_vacuum_threshold,
+                autovacuum_vacuum_scale_factor
+            );
+        """))
+        autocommit_sess.execute(text("alter system reset autovacuum_naptime;"))
+        autocommit_sess.execute(text("select pg_reload_conf();"))
 
 
 def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -6,7 +6,7 @@ import time
 import subprocess
 import os
 
-from common import http_request
+from common import http_request, wait_until
 
 
 def test_worker_will_not_block_drop_database(autocommit_sess):
@@ -53,88 +53,98 @@ def test_success_when_worker_is_up(sess):
     assert result == ''
 
 
-def test_worker_will_process_queue_when_up(sess):
+def test_worker_will_process_queue_when_up(sess, autocommit_sess):
     """
     Check that when pg background worker is down and requests arrive,
     it will process them once it wakes up
     """
 
-    # check worker up
-    (up,) = sess.execute(text("""
+    # Assert that background worker is worker up
+    (worker_is_up,) = sess.execute(text("""
         select is_worker_up();
     """)).fetchone()
-    assert up is not None
-    assert up == True
+    assert worker_is_up
 
-    # restart it
-    (restarted,) = sess.execute(text("""
+    # kill background worker
+    (killed,) = sess.execute(text("""
         select public.kill_worker();
     """)).fetchone()
-    assert restarted is not None
-    assert restarted == True
+    assert killed is not None
+    assert killed == True
 
-    time.sleep(0.1)
+    # Wait for background worker to go down
+    wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
+            select is_worker_up();
+        """)).fetchone(),
+        predicate=lambda result: not result[0],
+        timeout=5,
+        sleep_interval=0.1,
+        description="background worker to be down",
+    )
 
-    # check worker down
-    (up,) = sess.execute(text("""
-        select is_worker_up();
-    """)).fetchone()
-    assert up is not None
-    assert up == False
-
+    # Make a request while the worker is down
     http_request(sess, text(
         """
         select net.http_get('http://localhost:8080/pathological?status=200') from generate_series(1,10);
     """
     ))
 
-    # check requests where enqueued
+    # Check that requests were enqueued
     (count,) = sess.execute(text(
         """
         select count(*) from net.http_request_queue;
     """
     )).fetchone()
-
     assert count == 10
 
-    # check worker is still down
-    (up,) = sess.execute(text("""
+    # Check that worker is still down. Note that this is a bit racy
+    # as there is no guarantee that worker hasn't come back up at this
+    # time, but in practice this rarely fails because worker takes 2 
+    # seconds before coming back up, which is more than enough time
+    # to reach here.
+    (worker_is_up,) = sess.execute(text("""
         select is_worker_up();
     """)).fetchone()
-    assert up is not None
-    assert up == False
+    assert not worker_is_up
 
     sess.commit()
 
-    # wait until up
-    time.sleep(2.1)
+    # Wait for background worker to come back up
+    # It's critical to use autocommit_sess to see a new snapshot
+    # on each retry in wait_until, otherwise it might keep reading
+    # stale data and fail with a timeout.
+    wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
+            select is_worker_up();
+        """)).fetchone(),
+        predicate=lambda result: result[0],
+        timeout=5,
+        sleep_interval=0.1,
+        description="background worker to be up",
+    )
 
-    # check worker up
-    (up,) = sess.execute(text("""
-        select is_worker_up();
-    """)).fetchone()
-    assert up is not None
-    assert up == True
+    # Wait until new requests are in flight
+    wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
+            select count(*) from net.http_request_queue;
+        """)).fetchone(),
+        predicate=lambda result: result[0] == 0,
+        timeout=5,
+        sleep_interval=0.1,
+        description="request queue to drain",
+    )
 
-    # wait until new requests are done
-    time.sleep(1.1)
-
-    (count,) = sess.execute(text(
-        """
-        select count(*) from net.http_request_queue;
-    """
-    )).fetchone()
-
-    assert count == 0
-
-    (status_code, count) = sess.execute(text(
-        """
-        select status_code, count(*) from net._http_response group by status_code;
-    """
-    )).fetchone()
-
-    assert status_code == 200
-    assert count == 10
+    # Wait until all responses have arrived
+    wait_until(
+        fetch=lambda: autocommit_sess.execute(text("""
+            select status_code, count(*) from net._http_response group by status_code;
+        """)).fetchone(),
+        predicate=lambda result: result[0] == 200 and result[1] == 10,
+        timeout=5,
+        sleep_interval=0.1,
+        description="request queue to drain",
+    )
 
 
 def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
@@ -456,7 +466,7 @@ def test_processing_survives_postmaster_crash():
     engine.dispose()
 
 
-def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess, wait_until):
+def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
     """
     Check that the worker's INSERTs into net._http_response must be reflected
     in pg_stat_user_tables. Without this, autovacuum/autoanalyze can never be
@@ -524,7 +534,7 @@ def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess, wait_unt
     )
 
 
-def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_sess, wait_until):
+def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_sess):
     """
     Check that autoanalyze on net._http_response must fire after the worker
     writes enough rows. Without working pgstat counters, autovacuum/autoanalyze
@@ -602,7 +612,7 @@ def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_ses
     autocommit_sess.execute(text("select pg_reload_conf();"))
 
 
-def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess, wait_until):
+def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
     """
     Check that the pg_net worker must call pgstat_report_activity() so
     its row in pg_stat_activity has a valid state column.
@@ -658,7 +668,7 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess, wait
     )
 
 
-def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_sess, wait_until):
+def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_sess):
     """
     Check that when a schema named "net" exists but the pg_net tables don't
     (e.g. another extension installed into a schema named "net"), the worker

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -9,7 +9,7 @@ import os
 
 
 def test_worker_will_not_block_drop_database(autocommit_sess):
-    """the worker will not block a session doing drop database"""
+    """Check that the worker will not block a session doing drop database"""
 
     autocommit_sess.execute(text("create database foo;"))
     autocommit_sess.execute(text("drop database foo;"))
@@ -53,7 +53,10 @@ def test_success_when_worker_is_up(sess):
 
 
 def test_worker_will_process_queue_when_up(sess):
-    """when pg background worker is down and requests arrive, it will process them once it wakes up"""
+    """
+    Check that when pg background worker is down and requests arrive,
+    it will process them once it wakes up
+    """
 
     # check worker up
     (up,) = sess.execute(text("""
@@ -136,7 +139,10 @@ def test_worker_will_process_queue_when_up(sess):
 
 
 def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
-    """user can delete the queue rows while the worker is processing them"""
+    """
+    Check that a user can delete the queue rows while the worker is
+    processing them
+    """
 
     autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
     autocommit_sess.execute(text("select net.worker_restart();"))
@@ -168,7 +174,10 @@ def test_can_delete_rows_while_processing_queue(sess, autocommit_sess):
 
 
 def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
-    """a truncate will not wait until the worker is done processing all requests"""
+    """
+    Check that a truncate will not wait until the worker
+    is done processing all requests
+    """
 
     # ensure the worker will be processing the queue 1 by 1 (slowly) so it doesn't clear the whole
     # net.http_request_queue in one go
@@ -204,7 +213,10 @@ def test_truncate_wait_while_processing_queue(sess, autocommit_sess):
 
 
 def test_no_failure_on_drop_extension(sess):
-    """while waiting for a slow request, a drop extension should wait and not crash the worker"""
+    """
+    Check that while waiting for a slow request, a drop extension should
+    wait and not crash the worker
+    """
 
     (request_id,) = sess.execute(text("""
         select net.http_get(url := 'http://localhost:8080/pathological?status=200&delay=2');
@@ -233,7 +245,10 @@ def test_no_failure_on_drop_extension(sess):
 
 
 def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess):
-    """when the background worker is restarted while working, it will pick up the remaining requests"""
+    """
+    Check that when the background worker is restarted while working,
+    it will pick up the remaining requests
+    """
 
     autocommit_sess.execute(text("alter system set pg_net.batch_size to '1';"))
     autocommit_sess.execute(text("select net.worker_restart();"))
@@ -296,7 +311,7 @@ def test_worker_will_keep_processing_queue_when_restarted(sess, autocommit_sess)
 
 
 def test_new_requests_get_attended_asap(sess):
-    """new requests get attended as soon as possible"""
+    """Check that new requests get attended as soon as possible"""
 
     sess.execute(text(
         """
@@ -320,7 +335,10 @@ def test_new_requests_get_attended_asap(sess):
 
 
 def test_direct_inserts_no_requests(sess):
-    """direct insertions to the net.http_request_queue doesn't trigger new requests"""
+    """
+    Check that direct insertions to the net.http_request_queue doesn't
+    trigger new requests
+    """
 
     sess.execute(text(
         """
@@ -381,7 +399,10 @@ def test_direct_inserts_no_requests(sess):
 
 
 def test_processing_survives_postmaster_crash():
-    """the queue will continue processing even when a postmaster crash or restart happens"""
+    """
+    Check that the queue will continue processing even when a postmaster
+    crash or restart happens
+    """
 
     engine = create_engine("postgresql:///postgres")
     ac_engine = engine.execution_options(isolation_level="AUTOCOMMIT")
@@ -445,8 +466,9 @@ def test_processing_survives_postmaster_crash():
 
 
 def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
-    """the worker's INSERTs into net._http_response must be reflected in
-    pg_stat_user_tables. Without this, autovacuum/autoanalyze can never be
+    """
+    Check that the worker's INSERTs into net._http_response must be reflected
+    in pg_stat_user_tables. Without this, autovacuum/autoanalyze can never be
     scheduled and the table silently bloats.
     """
 
@@ -514,8 +536,9 @@ def test_worker_writes_increment_pgstat_counters(sess, autocommit_sess):
 
 
 def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_sess):
-    """autoanalyze on net._http_response must fire after the worker writes
-    enough rows. Without working pgstat counters, autovacuum/autoanalyze
+    """
+    Check that autoanalyze on net._http_response must fire after the worker
+    writes enough rows. Without working pgstat counters, autovacuum/autoanalyze
     never get scheduled and the table bloats - this is the primary symptom
     seen on production (slow expiry DELETEs from a bloated index).
     """
@@ -592,8 +615,9 @@ def test_worker_writes_trigger_autoanalyze_on_http_response(sess, autocommit_ses
 
 
 def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
-    """the pg_net worker must call pgstat_report_activity() so its row in
-    pg_stat_activity has a valid state column.
+    """
+    Check that the pg_net worker must call pgstat_report_activity() so
+    its row in pg_stat_activity has a valid state column.
     """
 
     autocommit_sess.execute(text("select net.wait_until_running();"))
@@ -643,9 +667,11 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
 
 
 def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_sess):
-    """when a schema named "net" exists but the pg_net tables don't (e.g. another
-    extension installed into a schema named "net"), the worker should treat the
-    extension as not installed instead of crash looping"""
+    """
+    Check that when a schema named "net" exists but the pg_net tables don't
+    (e.g. another extension installed into a schema named "net"), the worker
+    should treat the extension as not installed instead of crash looping
+    """
 
     sess.execute(text("drop extension pg_net cascade;"))
     sess.execute(text("create schema net;"))


### PR DESCRIPTION
This PR started off as an attempt to fix flaky tests but has grown into a mini overhaul of the tests. The changes include:

* Fixed many causes of flakiness, including hardcoded `time.sleep(...)` calls and race conditions and assumptions in the test code. The improvement is evidenced in the last 12 or so commits in this PR. Before this PR, the tests would fail quite often. Examples: [one](https://github.com/supabase/pg_net/actions/runs/30274356310), [two](https://github.com/supabase/pg_net/actions/runs/28860068242), [three](https://github.com/supabase/pg_net/actions/runs/28860065869), [four](https://github.com/supabase/pg_net/actions/runs/28754378777), and [many](https://github.com/supabase/pg_net/actions/runs/28721006742) [more](https://github.com/supabase/pg_net/actions/runs/28720661680). The new code waits for certain events to happen instead of hardcoded timeouts which is more robust.
* Made the code more readable by factoring out common code into `common.py` which also makes test smaller and easier to read.
* Removed some commented out code.
* Moved cleanup logic in tests into finally blocks to ensure one failing tests doesn't make other tests fail, improving test isolation.
* Formatted the code according to python standards.
* Added support for running a subset of tests locally during development. Updated `CONTRIBUTING.md` to show how to run a single or a subset of tests.
* Made sure on pushing a commit to a PR branch only one set of tests run. Previously two sets of tests would run in this case. Merging into `master` still triggers a separate test run.

Further improvement planned in a separate PR: currently test on each PG version unnecessarily pulls in all PG versions in nix store via xpg. This is ~700 MB worth of data pulled from the cache. This can be reduced if a single test could only copy that specific version of PG.