### PR TITLE
fix: worker crash loop when a "net" schema exists without the extension

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -222,7 +222,7 @@ static bool is_extension_locked(Oid ext_table_oids[static total_extension_tables
    * would crash loop on the queries that follow.
    */
   if (!OidIsValid(queue_oid) || !OidIsValid(resp_oid)) {
-    ereport(LOG,
+    ereport(WARNING,
             errmsg("schema \"net\" exists but the pg_net extension tables are missing, skipping "
                    "request processing"),
             errhint("The schema \"net\" might be used by another extension or be left over from a "

--- a/src/worker.c
+++ b/src/worker.c
@@ -222,6 +222,11 @@ static bool is_extension_locked(Oid ext_table_oids[static total_extension_tables
    * would crash loop on the queries that follow.
    */
   if (!OidIsValid(queue_oid) || !OidIsValid(resp_oid)) {
+    ereport(LOG,
+            errmsg("schema \"net\" exists but the pg_net extension tables are missing, skipping "
+                   "request processing"),
+            errhint("The schema \"net\" might be used by another extension or be left over from a "
+                    "partially dropped pg_net installation."));
     return false;
   }
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -215,6 +215,16 @@ static bool is_extension_locked(Oid ext_table_oids[static total_extension_tables
   Oid queue_oid = get_relname_relid("http_request_queue", net_oid);
   Oid resp_oid  = get_relname_relid("_http_response", net_oid);
 
+  /*
+   * The "net" schema can exist without the extension tables, e.g. when another
+   * extension is installed into a schema named "net". ConditionalLockRelationOid
+   * doesn't validate the oid, so locking InvalidOid would succeed and the worker
+   * would crash loop on the queries that follow.
+   */
+  if (!OidIsValid(queue_oid) || !OidIsValid(resp_oid)) {
+    return false;
+  }
+
   bool is_locked = ConditionalLockRelationOid(queue_oid, AccessShareLock) &&
                    ConditionalLockRelationOid(resp_oid, AccessShareLock);
 

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -677,3 +677,7 @@ def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_
 
     sess.execute(text("drop schema net;"))
     sess.commit()
+
+    # exit the worker so it flushes its gcov counters; this is the last test of the
+    # suite and the immediate shutdown at the end would lose its coverage data
+    autocommit_sess.execute(text("select kill_worker();"))

--- a/test/test_worker_behavior.py
+++ b/test/test_worker_behavior.py
@@ -639,3 +639,41 @@ def test_worker_reports_activity_in_pg_stat_activity(sess, autocommit_sess):
         "state column stays NULL."
     )
 
+
+
+def test_worker_idles_when_net_schema_exists_without_extension(sess, autocommit_sess):
+    """when a schema named "net" exists but the pg_net tables don't (e.g. another
+    extension installed into a schema named "net"), the worker should treat the
+    extension as not installed instead of crash looping"""
+
+    sess.execute(text("drop extension pg_net cascade;"))
+    sess.execute(text("create schema net;"))
+    sess.commit()
+
+    # restart the worker so it comes back up with a pending wake signal
+    autocommit_sess.execute(text("select kill_worker();"))
+
+    # wait for the worker to come back up (bgw_restart_time is 1 second)
+    pid = None
+    deadline = time.time() + 5.0
+    while time.time() < deadline:
+        row = autocommit_sess.execute(text(
+            "select pid from pg_stat_activity where backend_type ilike '%pg_net%';"
+        )).fetchone()
+        if row:
+            pid = row[0]
+            break
+        time.sleep(0.1)
+    assert pid is not None, "pg_net worker did not come back up after restart"
+
+    # wait several restart cycles; a crash loop would respawn the worker with a new pid
+    time.sleep(3)
+
+    row = autocommit_sess.execute(text(
+        "select pid from pg_stat_activity where backend_type ilike '%pg_net%';"
+    )).fetchone()
+    assert row is not None, "pg_net worker is down, it crashed after seeing the net schema"
+    assert row[0] == pid, "pg_net worker restarted, it's crash looping on the net schema"
+
+    sess.execute(text("drop schema net;"))
+    sess.commit()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a schema named `net` exists but the pg_net tables don't — e.g. another extension such as [pgsql-http](https://github.com/pramsey/pgsql-http) installed into a schema named `net`, while pg_net itself is not installed — the background worker crash loops once per second:

```
ERROR:  relation "net._http_response" does not exist (SQLSTATE 42P01)
LOG:  background worker "pg_net 0.19.5 worker" (PID ...) exited with exit code 1
```

`is_extension_locked()` decides whether the extension is installed before the worker touches its tables. It verifies the `net` schema exists, then resolves the two table oids with `get_relname_relid()`, but never checks the results for `InvalidOid`. `ConditionalLockRelationOid()` doesn't validate the oid either — it just builds a locktag from whatever oid it's given — so "locking" `InvalidOid` succeeds and the worker proceeds to `DELETE FROM net._http_response`, which fails with `42P01`. The ERROR exits the worker, `net_on_exit()` re-arms `should_wake`, and the restarted worker (`bgw_restart_time` = 1s) immediately repeats the cycle.

Seen in production on a Supabase project where pgsql-http was installed into a schema named `net` (its cron jobs call `net.http(...)`) and pg_net was never installed — pg_net is in `shared_preload_libraries` there, so the worker runs regardless.

## Fix

Treat invalid table oids as "extension not installed": return false from `is_extension_locked()` when either table oid is invalid. The worker then logs `pg_net extension not loaded` (DEBUG1) and sleeps on its latch, same as when no `net` schema exists at all.

## Tests

`test_worker_idles_when_net_schema_exists_without_extension` (test/test_worker_behavior.py): drops the extension, creates a bare `net` schema, kills the worker so it comes back up with a pending wake signal, then asserts the worker is up and keeps the same pid across several restart-time windows.

- With the fix: full suite passes (63 passed).
- Without the fix: the test fails with `pg_net worker did not come back up after restart` — the worker is crash looping, so it is down for most of every 1-second window.