### PR TITLE
bump to 0.20.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ else
 endif
 
 EXTENSION = pg_net
-EXTVERSION = 0.20.3
+EXTVERSION = 0.20.4
 
 DATA = $(wildcard sql/*--*.sql)
 

--- a/sql/pg_net--0.20.3--0.20.4.sql
+++ b/sql/pg_net--0.20.3--0.20.4.sql
@@ -1,0 +1,1 @@
+-- no SQL changes in 0.20.4


### PR DESCRIPTION
Releases the fixes merged since 0.20.3. No SQL changes, C-only:

- #264 — fix: worker crash loop when a "net" schema exists without the extension
- #262 — build: could not build with pg versions older than 16 on macos

Linear: https://linear.app/supabase/issue/PSQL-1372/release-pg-net-fix-for-worker-crash-loop