### PR TITLE
fix: pg19beta1 compatibility 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg-version: ['12', '13', '14', '15', '16', '17', '18']
+        pg-version: ['12', '13', '14', '15', '16', '17', '18', '19']
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-SRC_DIR = src
-
 # the `-Wno`s quiet C90 warnings
 PG_CFLAGS = -std=c11 -Wextra -Wall -Werror \
 	-Wno-declaration-after-statement \
@@ -45,12 +43,13 @@ REGRESS = $(patsubst test/sql/%.sql,%,$(TESTS))
 REGRESS_OPTS = --use-existing --inputdir=test
 
 MODULE_big = $(EXTENSION)
-SRC = $(wildcard $(SRC_DIR)/*.c)
+HEADERS = $(wildcard src/*.h)
+SOURCES = $(wildcard src/*.c)
 
 ifdef BUILD_DIR
-OBJS = $(patsubst $(SRC_DIR)/%.c, $(BUILD_DIR)/%.o, $(SRC))
+OBJS = $(patsubst src/%.c, $(BUILD_DIR)/%.o, $(SOURCES))
 else
-OBJS = $(patsubst $(SRC_DIR)/%.c, src/%.o, $(SRC)) # if no BUILD_DIR, just build on src so standard PGXS `make` works
+OBJS = $(patsubst src/%.c, src/%.o, $(SOURCES)) # if no BUILD_DIR, just build on src so standard PGXS `make` works
 endif
 
 SHLIB_LINK = -lcurl
@@ -68,7 +67,7 @@ $(BUILD_DIR)/.gitignore: sql/$(EXTENSION)--$(EXTVERSION).sql $(EXTENSION).contro
 	cp sql/$(EXTENSION)--$(EXTVERSION).sql $(BUILD_DIR)/extension
 	echo "*" > $(BUILD_DIR)/.gitignore
 
-$(BUILD_DIR)/%.o: $(SRC_DIR)/%.c $(BUILD_DIR)/.gitignore
+$(BUILD_DIR)/%.o: src/%.c $(HEADERS) $(BUILD_DIR)/.gitignore
 	$(CC) $(CPPFLAGS) $(CFLAGS) -c $< -o $@
 
 $(BUILD_DIR)/$(EXTENSION).$(SHARED_EXT): $(EXTENSION).$(SHARED_EXT)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # the `-Wno`s quiet C90 warnings
 PG_CFLAGS = -std=c11 -Wextra -Wall -Werror \
+	-Wold-style-definition \
 	-Wno-declaration-after-statement \
 	-Wno-vla \
 	-Wno-long-long

--- a/flake.lock
+++ b/flake.lock
@@ -43,16 +43,16 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1778705163,
-        "narHash": "sha256-fCZFKnoE5zYoEMSEDLYZ87RELO8PYcVjATmnQZhRtAQ=",
+        "lastModified": 1782266378,
+        "narHash": "sha256-moRjdGvymGEyREU4++qpNzDuUN+nVC69CUYjhuY4Yzs=",
         "owner": "steve-chavez",
         "repo": "xpg",
-        "rev": "c92037ecab9b368aa233c908d4d978c465bb82de",
+        "rev": "d81725666a193c644fe0db96a988ece66edf460c",
         "type": "github"
       },
       "original": {
         "owner": "steve-chavez",
-        "ref": "v2.1.0",
+        "ref": "v2.4.0",
         "repo": "xpg",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     # 2025-11-13
     nixpkgs.url = "github:NixOS/nixpkgs/91c9a64ce2a84e648d0cf9671274bb9c2fb9ba60";
     xpg = {
-      url = "github:steve-chavez/xpg/v2.1.0";
+      url = "github:steve-chavez/xpg/v2.4.0";
     };
   };
 

--- a/src/core.c
+++ b/src/core.c
@@ -104,7 +104,7 @@ void init_curl_handle(CurlHandle *handle, RequestQueueRow row) {
   EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_TIMEOUT_MS, (long)handle->timeout_milliseconds);
   EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_PRIVATE, handle);
   EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_FOLLOWLOCATION, (long)true);
-  if (log_min_messages <= DEBUG2) EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_VERBOSE, 1L);
+  if (LOG_MIN_MESSAGES <= DEBUG2) EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_VERBOSE, 1L);
 #if LIBCURL_VERSION_NUM >= 0x075500 /* libcurl 7.85.0 */
   EREPORT_CURL_SETOPT(handle->ez_handle, CURLOPT_PROTOCOLS_STR, "http,https");
 #else
@@ -218,23 +218,20 @@ RequestQueueRow get_request_queue_row(HeapTuple spi_tupval, TupleDesc spi_tupdes
 
 static Jsonb *jsonb_headers_from_curl_handle(CURL *ez_handle) {
   struct curl_header *header, *prev = NULL;
-
-  JsonbParseState *headers = NULL;
-  (void)pushJsonbValue(&headers, WJB_BEGIN_OBJECT, NULL);
+  PG_JSONB_INIT_STATE(headers);
+  (void)PG_JSONB_PUSH(headers, WJB_BEGIN_OBJECT, NULL);
 
   while ((header = curl_easy_nextheader(ez_handle, CURLH_HEADER, 0, prev))) {
     JsonbValue key   = {.type = jbvString,
                         .val  = {.string = {.val = header->name, .len = strlen(header->name)}}};
     JsonbValue value = {.type = jbvString,
                         .val  = {.string = {.val = header->value, .len = strlen(header->value)}}};
-    (void)pushJsonbValue(&headers, WJB_KEY, &key);
-    (void)pushJsonbValue(&headers, WJB_VALUE, &value);
+    (void)PG_JSONB_PUSH(headers, WJB_KEY, &key);
+    (void)PG_JSONB_PUSH(headers, WJB_VALUE, &value);
     prev = header;
   }
 
-  Jsonb *jsonb_headers = JsonbValueToJsonb(pushJsonbValue(&headers, WJB_END_OBJECT, NULL));
-
-  return jsonb_headers;
+  return PG_JSONB_OBJECT_FINISH(headers);
 }
 
 void insert_response(CurlHandle *handle, CURLcode curl_return_code) {

--- a/src/event.c
+++ b/src/event.c
@@ -20,7 +20,7 @@ inline int wait_event(int fd, event *events, size_t maxevents, int timeout_milli
   return epoll_wait(fd, events, maxevents, timeout_milliseconds);
 }
 
-inline int event_monitor() {
+inline int event_monitor(void) {
   return epoll_create1(0);
 }
 
@@ -150,7 +150,7 @@ int inline wait_event(int fd, event *events, size_t maxevents, int timeout_milli
                 &(struct timespec){.tv_sec = timeout_milliseconds / 1000});
 }
 
-int inline event_monitor() {
+int inline event_monitor(void) {
   return kqueue();
 }
 

--- a/src/pg_prelude.h
+++ b/src/pg_prelude.h
@@ -51,6 +51,32 @@
 #define PG15_GTE (PG_VERSION_NUM >= 150000)
 #define PG17_LT (PG_VERSION_NUM < 170000)
 
+#if PG_VERSION_NUM >= 190000
+#  define LOG_MIN_MESSAGES *log_min_messages
+
+// clang-format off
+#  define PG_SIGNAL_PARAMS                                                                         \
+    __attribute__((unused)) int   postgres_signal_arg,\
+    __attribute__((unused)) const pg_signal_info *pg_siginfo
+// clang-format on
+#  define PG_SIGNAL_ARGS postgres_signal_arg, pg_siginfo
+
+#  define PG_JSONB_INIT_STATE(name) JsonbInState name = {0}
+#  define PG_JSONB_PUSH(state, action, value) pushJsonbValue(&(state), (action), (value))
+#  define PG_JSONB_OBJECT_FINISH(state)                                                            \
+    (PG_JSONB_PUSH((state), WJB_END_OBJECT, NULL), JsonbValueToJsonb((state).result))
+#else
+#  define LOG_MIN_MESSAGES log_min_messages
+
+#  define PG_SIGNAL_PARAMS __attribute__((unused)) int postgres_signal_arg
+#  define PG_SIGNAL_ARGS postgres_signal_arg
+
+#  define PG_JSONB_INIT_STATE(name) JsonbParseState *name = NULL
+#  define PG_JSONB_PUSH(state, action, value) pushJsonbValue(&(state), (action), (value))
+#  define PG_JSONB_OBJECT_FINISH(state)                                                            \
+    JsonbValueToJsonb(PG_JSONB_PUSH((state), WJB_END_OBJECT, NULL))
+#endif
+
 const char *xact_event_name(XactEvent event);
 
 #if PG17_LT

--- a/src/worker.c
+++ b/src/worker.c
@@ -131,7 +131,7 @@ Datum wake(__attribute__((unused)) PG_FUNCTION_ARGS) {
   PG_RETURN_VOID();
 }
 
-static void handle_sigterm(__attribute__((unused)) SIGNAL_ARGS) {
+static void handle_sigterm(PG_SIGNAL_PARAMS) {
   int save_errno = errno;
   pg_atomic_write_u32(&worker_state->got_restart, 1);
   pg_write_barrier();
@@ -139,7 +139,7 @@ static void handle_sigterm(__attribute__((unused)) SIGNAL_ARGS) {
   errno = save_errno;
 }
 
-static void handle_sighup(__attribute__((unused)) SIGNAL_ARGS) {
+static void handle_sighup(PG_SIGNAL_PARAMS) {
   int save_errno = errno;
   got_sighup     = true;
   if (worker_state->shared_latch) SetLatch(worker_state->shared_latch);
@@ -152,11 +152,11 @@ static void handle_sighup(__attribute__((unused)) SIGNAL_ARGS) {
  *DROP DATATABASE from finishing since our worker would be sleeping and not reach
  *CHECK_FOR_INTERRUPTS()
  */
-static void handle_sigusr1(SIGNAL_ARGS) {
+static void handle_sigusr1(PG_SIGNAL_PARAMS) {
   int save_errno = errno;
   if (worker_state->shared_latch) SetLatch(worker_state->shared_latch);
   errno = save_errno;
-  procsignal_sigusr1_handler(postgres_signal_arg);
+  procsignal_sigusr1_handler(PG_SIGNAL_ARGS);
 }
 
 static void publish_state(WorkerStatus s) {


### PR DESCRIPTION
Fixes https://github.com/supabase/pg_net/issues/257.

pg 19 changes some interfaces, these are now abstracted in pg_prelude.h:

* log_min_messages
* signal parameters and args
* jsonb state

Also adds pg 19 on CI.