### PR TITLE
fix: reject request headers containing CR or LF

### DIFF
--- a/src/core.c
+++ b/src/core.c
@@ -22,6 +22,29 @@ static size_t body_cb(void *contents, size_t size, size_t nmemb, void *userp) {
   return realsize;
 }
 
+// Reject a header containing CR or LF before it reaches libcurl.
+//
+// libcurl appends the CRLF terminator itself, so an embedded CR/LF ends the
+// header early and everything after it is taken by the receiving parser as
+// further headers or as the start of the body (request splitting). Only the
+// header name is included in the error: the value is attacker-controlled and
+// commonly holds credentials, so it must not be copied into the server log.
+static void reject_crlf_in_header(const char *hdr) {
+  size_t bad = strcspn(hdr, "\r\n");
+
+  if (hdr[bad] != '\0') {
+    size_t name_len = strcspn(hdr, ":");
+
+    // A header with no ':' has no name to report, so bound what is echoed.
+    if (name_len > bad) {
+      name_len = bad;
+    }
+
+    ereport(ERROR, errmsg("header \"%.*s\" contains a carriage return or line feed",
+                          (int)name_len, hdr));
+  }
+}
+
 static struct curl_slist *pg_text_array_to_slist(ArrayType *array, struct curl_slist *headers) {
   ArrayIterator iterator;
   Datum         value;
@@ -36,6 +59,7 @@ static struct curl_slist *pg_text_array_to_slist(ArrayType *array, struct curl_s
     }
 
     hdr = TextDatumGetCString(value);
+    reject_crlf_in_header(hdr);
     EREPORT_CURL_SLIST_APPEND(headers, hdr);
     pfree(hdr);
   }

--- a/test/test_http_header_crlf.py
+++ b/test/test_http_header_crlf.py
@@ -1,0 +1,77 @@
+from sqlalchemy import text
+from common import collect_response_sync, http_request
+
+
+def test_http_request_header_with_lf_is_rejected(sess):
+    """
+    A header value ending in a line feed must not be sent.
+
+    libcurl appends the CRLF terminator itself, so an embedded LF closes the
+    header early and the receiving parser reads whatever follows as more
+    headers or as the body (request splitting).
+    """
+
+    request_id = http_request(
+        sess,
+        text(
+            r"""
+        select net.http_get(
+            url:='http://localhost:8080/headers',
+            headers:=jsonb_build_object('Injected', 'value' || chr(10) || 'X-Smuggled: 1')
+        );
+    """
+        ),
+    )
+
+    response = collect_response_sync(sess, request_id)
+
+    assert response is not None
+    assert response["status"] == "ERROR"
+    assert "carriage return or line feed" in response["message"]
+    # The header name is safe to surface; the value may hold credentials.
+    assert "Injected" in response["message"]
+    assert "X-Smuggled" not in response["message"]
+
+
+def test_http_request_header_with_cr_is_rejected(sess):
+    """A carriage return is rejected for the same reason as a line feed."""
+
+    request_id = http_request(
+        sess,
+        text(
+            r"""
+        select net.http_get(
+            url:='http://localhost:8080/headers',
+            headers:=jsonb_build_object('Injected', 'value' || chr(13) || 'X-Smuggled: 1')
+        );
+    """
+        ),
+    )
+
+    response = collect_response_sync(sess, request_id)
+
+    assert response is not None
+    assert response["status"] == "ERROR"
+    assert "carriage return or line feed" in response["message"]
+
+
+def test_http_ordinary_headers_still_sent(sess):
+    """The check must not affect headers that contain no CR or LF."""
+
+    request_id = http_request(
+        sess,
+        text(
+            """
+        select net.http_get(
+            url:='http://localhost:8080/headers',
+            headers:='{"pytest-header": "pytest-header", "accept": "application/json"}'
+        );
+    """
+        ),
+    )
+
+    response = collect_response_sync(sess, request_id)
+
+    assert response is not None
+    assert response["status"] == "SUCCESS"
+    assert "pytest-header" in response["body"]


### PR DESCRIPTION
Closes #274.

Header values went straight to `curl_slist_append` with no validation. libcurl appends the CRLF terminator itself, so a value carrying its own CR or LF closes the header early and everything after it is read by the receiving parser as further headers or as the start of the body. A value interpolated from untrusted input can therefore inject headers into the outgoing request, or split it.

This rejects any header containing CR or LF before it reaches libcurl, so a poisoned request fails instead of being sent. The check is in `pg_text_array_to_slist` rather than in the SQL API so it also covers rows inserted directly into `net.http_request_queue`, and it uses the same `ereport(ERROR, ...)` style already used in that function.

Only the header name is included in the error. The value is the attacker-controlled part and commonly holds credentials, so it must not be copied into the server log; when the CR or LF appears before any `:`, the reported name is truncated at that point so the smuggled text cannot reach the log that way either.

**Verification**

- Builds clean in-tree against PostgreSQL 17 (`postgresql-server-dev-17`, `libcurl4-openssl-dev`), including the repo's `-Werror -Wextra -Wall` settings.
- The matching logic was exercised standalone over 11 cases: ordinary headers (including `X-Empty:` and a header with no colon) are unaffected; LF, CR, CRLF, trailing-LF and leading-LF are all rejected; and the no-colon-before-CRLF case confirms the injected text never appears in the error.
- `test/test_http_header_crlf.py` adds regression tests in the style of `test_http_malformed_headers.py`, including one asserting ordinary headers are still sent. I was not able to run the Nix `net-with-nginx` harness locally, so those tests are unrun on my side — worth a look in CI.