### PR TITLE
fix: only clean up worker resources this process created

### DIFF
--- a/src/worker.c
+++ b/src/worker.c
@@ -165,6 +165,19 @@ static void publish_state(WorkerStatus s) {
   ConditionVariableBroadcast(&worker_state->cv);
 }
 
+// How far *this* process got through startup. worker_state lives in shared memory, so its epfd
+// and curl_mhandle outlive the process that created them: a worker that exits before creating
+// its own - while BackgroundWorkerInitializeConnection() fails, for instance - would otherwise
+// close a file descriptor number and free a heap pointer belonging to a previous worker.
+typedef enum {
+  WORKER_INIT_NONE = 0,
+  WORKER_INIT_CURL_GLOBAL,
+  WORKER_INIT_EV_MONITOR,
+  WORKER_INIT_CURL_MHANDLE,
+} WorkerInitStage;
+
+static WorkerInitStage worker_init_stage = WORKER_INIT_NONE;
+
 static void net_on_exit(__attribute__((unused)) int code, __attribute__((unused)) Datum arg) {
   worker_should_restart = false;
   pg_atomic_write_u32(&worker_state->should_wake,
@@ -172,10 +185,21 @@ static void net_on_exit(__attribute__((unused)) int code, __attribute__((unused)
 
   worker_state->shared_latch = NULL;
 
-  ev_monitor_close(worker_state);
+  if (worker_init_stage >= WORKER_INIT_EV_MONITOR) {
+    ev_monitor_close(worker_state);
+    worker_state->epfd = -1;
+  }
 
-  curl_multi_cleanup(worker_state->curl_mhandle);
-  curl_global_cleanup();
+  if (worker_init_stage >= WORKER_INIT_CURL_MHANDLE) {
+    curl_multi_cleanup(worker_state->curl_mhandle);
+    worker_state->curl_mhandle = NULL;
+  }
+
+  if (worker_init_stage >= WORKER_INIT_CURL_GLOBAL) {
+    curl_global_cleanup();
+  }
+
+  worker_init_stage = WORKER_INIT_NONE;
 }
 
 // wait according to the wait type while ensuring interrupts are processed while waiting
@@ -266,15 +290,18 @@ void pg_net_worker(__attribute__((unused)) Datum main_arg) {
   int curl_ret = curl_global_init(CURL_GLOBAL_ALL);
   if (curl_ret != CURLE_OK)
     ereport(ERROR, errmsg("curl_global_init() returned %s\n", curl_easy_strerror(curl_ret)));
+  worker_init_stage = WORKER_INIT_CURL_GLOBAL;
 
   worker_state->epfd = event_monitor();
 
   if (worker_state->epfd < 0) {
     ereport(ERROR, errmsg("Failed to create event monitor file descriptor"));
   }
+  worker_init_stage = WORKER_INIT_EV_MONITOR;
 
   worker_state->curl_mhandle = curl_multi_init();
   if (!worker_state->curl_mhandle) ereport(ERROR, errmsg("curl_multi_init()"));
+  worker_init_stage = WORKER_INIT_CURL_MHANDLE;
 
   set_curl_mhandle(worker_state);
 


### PR DESCRIPTION
Fixes #276.

### The problem

`net_on_exit()` is registered at `worker.c:251`, before `BackgroundWorkerInitializeConnection()` at 258 and long before `event_monitor()` / `curl_multi_init()` at 270/276 — but it closed `worker_state->epfd` and freed `worker_state->curl_mhandle` unconditionally.

Both fields live in `WorkerState` (`core.h:17-18`), which is shared memory, so they outlive the process that created them. A worker terminated **during startup** — its database dropped, `datallowconn = false`, or a `pg_terminate_backend()` racing the 1 s restart — therefore ran the cleanup on an fd number and a heap pointer belonging to the *previous* worker. The double free is a SIGSEGV, and the postmaster answers a background worker crash by restarting the entire cluster into recovery.

One consequence beyond the report: `ev_monitor_close()` also does `close(timerfd)`, and `timerfd` is `static int timerfd = 0` (`event.c:13`). In a process that never created one it is still 0, so the same path closes **fd 0**.

### The change

Track how far *this* process got through startup, and unwind only that far.

The stage is process-local rather than another `WorkerState` field, which matters for a case the report doesn't need but which exists anyway: a worker `SIGKILL`ed without ever running the callback leaves the shared fields populated, so resetting them to sentinels on exit would still leave the next worker trusting stale values. A fresh process starts at `NONE` regardless of how the last one died.

The shared fields are still reset after a real cleanup, so they never hold a freed pointer.

### Verification

**I could not build or run this** — pg_net's dev environment is Nix-based and this is a Windows machine, so CI is the real check. What I could do was model the two exit paths standalone, driving the same sequence (worker A starts fully and exits; worker B restarts and dies during startup) against the old and new `net_on_exit`:

```
BEFORE - cleanup runs unconditionally
   worker A owned epfd=4 timerfd=3
   worker B closed 2 fd(s): 4 0
   worker B freed A's curl handle: YES - double free, this is the SIGSEGV

AFTER  - cleanup guarded by worker_init_stage
   worker A owned epfd=4 timerfd=3
   worker B closed 0 fd(s):
   worker B freed A's curl handle: no
```

That exercises the control flow and the shared-state lifetime, not the real curl or epoll calls — it is evidence about the ordering bug, not a substitute for the suite.

**No test is included.** The reporter measured the race at 6 crashes in 16 CI runs, so a test built on that timing would be flaky. A deterministic one looks possible — point `pg_net.database_name` at a database that does not exist, reload, and terminate the worker so the restart always fails inside `BackgroundWorkerInitializeConnection` — but I would be guessing at whether it survives your harness, since I cannot run it. Happy to add it if you want that shape, or if you would rather it went in `test_worker_behavior.py` next to `test_worker_will_not_block_drop_database` (which, as the issue notes, drops `foo` and so never terminates the worker connected to `postgres`).

**AI disclosure:** this change was prepared with the assistance of Claude Code. I reviewed the change and the analysis before opening, and I stand behind them as my own.
