### PR TITLE
docs: fix README timeout defaults and add http_delete body param

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ net.http_delete(
     parallel safe
     language plpgsql
     security definer
+```
 
 ### Examples:
 The following examples use the [Dummy Rest API](https://dummy.restapiexample.com/employees).

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ net.http_get(
     -- key/values to be included in request headers
     headers jsonb default '{}'::jsonb,
     -- the maximum number of milliseconds the request may take before being cancelled
-    timeout_milliseconds int default 1000
+    timeout_milliseconds int default 5000
 )
     -- request_id reference
     returns bigint
@@ -253,7 +253,7 @@ net.http_post(
     -- key/values to be included in request headers
     headers jsonb default '{"Content-Type": "application/json"}'::jsonb,
     -- the maximum number of milliseconds the request may take before being cancelled
-    timeout_milliseconds int default 1000
+    timeout_milliseconds int default 5000
 )
     -- request_id reference
     returns bigint
@@ -328,7 +328,9 @@ net.http_delete(
     -- key/values to be included in request headers
     headers jsonb default '{}'::jsonb,
     -- the maximum number of milliseconds the request may take before being cancelled
-    timeout_milliseconds int default 2000
+    timeout_milliseconds int default 5000,
+    -- body of the DELETE request
+    body jsonb default null
 )
     -- request_id reference
     returns bigint
@@ -338,7 +340,6 @@ net.http_delete(
     parallel safe
     language plpgsql
     security definer
-```
 
 ### Examples:
 The following examples use the [Dummy Rest API](https://dummy.restapiexample.com/employees).


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update. The README's published function signatures do not match the shipped functions.

## What is the current behavior?

The README documents timeout_milliseconds int default 1000 for net.http_get and net.http_post, and default 2000 for net.http_delete. It also shows net.http_delete without a body parameter.

## What is the new behavior?

All three signatures show timeout_milliseconds int default 5000, and net.http_delete includes its body parameter, matching sql/pg_net.sql on master:

create or replace function net.http_delete(
    url text,
    params jsonb default '{}'::jsonb,
    headers jsonb default '{}'::jsonb,
    timeout_milliseconds int default 5000,
    body jsonb default null
)

## Additional context

The same two errors, with a different wrong timeout value, appear in the Supabase docs guide for pg_net. I opened a separate PR for that page.
