### PR TITLE
remove pg12/pg13 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        pg-version: ["12", "13", "14", "15", "16", "17", "18", "19"]
+        pg-version: ["14", "15", "16", "17", "18", "19"]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,11 +55,11 @@ $ nix develop
 # test on latest pg
 $ xpg test
 
-# test on pg 12
-$ xpg -v 12 test
+# test on pg 14
+$ xpg -v 14 test
 
-# test on pg 13
-$ xpg -v 13 test
+# test on pg 15
+$ xpg -v 15 test
 ```
 
 This will spawn a local db and an nginx server for testing.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # PG_NET
 *A PostgreSQL extension that enables asynchronous (non-blocking) HTTP/HTTPS requests with SQL*.
 
-Requires libcurl >= 7.83. Compatible with PostgreSQL > = 12.
+Requires libcurl >= 7.83. Compatible with PostgreSQL > = 14.
 
-![PostgreSQL version](https://img.shields.io/badge/postgresql-12+-blue.svg)
+![PostgreSQL version](https://img.shields.io/badge/postgresql-14+-blue.svg)
 [![License](https://img.shields.io/pypi/l/markdown-subtemplate.svg)](https://github.com/supabase/pg_net/blob/master/LICENSE)
 [![Coverage Status](https://coveralls.io/repos/github/supabase/pg_net/badge.svg)](https://coveralls.io/github/supabase/pg_net)
 [![Tests](https://github.com/supabase/pg_net/actions/workflows/main.yml/badge.svg)](https://github.com/supabase/pg_net/actions)


### PR DESCRIPTION
Currently CI supports postgres 12-19. Also there are references in the docs to 12 and 13 and pg_net is officially compatible with postgres 12. Postgres 12 and 13 are officially EOL, are not supported by the postgres community and no longer receive patches, bug fixes, security updates, etc.

Given all of this I believe that it is prudent to remove pg12 and 13 support and CI pipelines, unless there is a reason that I am not aware of to keep this around.

A policy like this would be in line with what I believe is the policy of the majority of postgres extensions. For example:
- pg_duckdb https://github.com/duckdb/pg_duckdb/blob/ee38d3b540ecea1d93683ba99bdcec5632a21eaf/.github/workflows/build_and_test.yaml#L36
- pg_partman https://github.com/pgpartman/pg_partman/blob/c737cc1d32a46a37120aa691f7dd0bce6ad07660/.github/workflows/ci.yml#L12
- postgis https://github.com/postgis/postgis/blob/48ead8f0784912aae0a0bae8fd8778e629565688/.github/workflows/ci.yml#L21