### PR TITLE
fix: read response headers from the final redirect hop

### DIFF
--- a/nix/nginx/conf/custom.conf
+++ b/nix/nginx/conf/custom.conf
@@ -59,10 +59,12 @@ location /delete_w_body {
 }
 
 location /redirect_me {
+  add_header X-Redirect-Hop first;
   return 301 /to_here;
 }
 
 location /to_here {
+  add_header X-Final-Hop last;
   echo 'I got redirected';
 }
 

--- a/src/core.c
+++ b/src/core.c
@@ -221,7 +221,7 @@ static Jsonb *jsonb_headers_from_curl_handle(CURL *ez_handle) {
   PG_JSONB_INIT_STATE(headers);
   (void)PG_JSONB_PUSH(headers, WJB_BEGIN_OBJECT, NULL);
 
-  while ((header = curl_easy_nextheader(ez_handle, CURLH_HEADER, 0, prev))) {
+  while ((header = curl_easy_nextheader(ez_handle, CURLH_HEADER, -1, prev))) {
     JsonbValue key   = {.type = jbvString,
                         .val  = {.string = {.val = header->name, .len = strlen(header->name)}}};
     JsonbValue value = {.type = jbvString,

--- a/test/test_http_get_collect.py
+++ b/test/test_http_get_collect.py
@@ -112,6 +112,23 @@ def test_http_get_collect_with_redirect(sess):
     assert response["body"] == "I got redirected\n"
 
 
+def test_http_get_collect_redirect_headers_from_final_response(sess):
+    """Response headers must come from the final hop, not the redirect"""
+
+    request_id = http_request(sess, text(
+        """
+        select net.http_get('http://localhost:8080/redirect_me');
+    """
+    ))
+
+    response = collect_response_sync(sess, request_id)
+
+    assert response is not None
+    assert response["status_code"] == 200
+    assert "X-Final-Hop" in response["headers"]
+    assert "X-Redirect-Hop" not in response["headers"]
+
+
 def test_http_get_ipv6(sess):
     """Test pg_net can resolve an ipv6 only server"""
 


### PR DESCRIPTION
When a request is redirected, the `headers` stored in `net._http_response` were taken from the first response (the redirect) while `status_code`, `content` and `content_type` came from the final one. This reads the headers from the final response as well.

Adds a test that follows the existing `/redirect_me` -> `/to_here` redirect in the nginx harness and checks the stored headers belong to the final response.